### PR TITLE
fixed subtl.py from trying to parse a port string as integer

### DIFF
--- a/src/lib/subtl/subtl.py
+++ b/src/lib/subtl/subtl.py
@@ -70,6 +70,9 @@ class UdpTrackerClient:
         # Check and raise if missing fields
         self._check_fields(args, fields)
 
+        # Convert argument port from string to integer for correct struct.pack execution
+        args['port'] = int(args['port'])
+
         # Humans tend to use hex representations of the hash. Wasteful humans.
         args['info_hash'] = norm_info_hash(args['info_hash'])
 


### PR DESCRIPTION
When running zeronet.py with the --fileserver_port argument set to an open port, the following error occurs

[22:42:28] Site:1EU1tb..E4Vr Tracker error: error: cannot convert argument to integer in Site.py line 233 > subtl.py line 79

As the fileserver_port is of the type string, parsing it to integer fixes this issue.
I don't know if the subtl library is the correct place to implement this fix, but for now it helped me to get it to run.