### PR TITLE
Pip Requirements File Added

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+gevent==1.0.1
+pyzmq==14.4.1
+msgpack-python==0.4.4


### PR DESCRIPTION
Added a requirements.txt file for easier requirement building.

Instead of:
* pip install pyzmq
* pip install gevent
* pip install msg-pack python

It's:
```
pip install -r requirements.txt
```