### PR TITLE
start.py script to start the server and launch a new browser tab

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+from multiprocessing import Process
+import webbrowser
+import zeronet
+
+server = Process(target=zeronet.main)
+server.start()
+url = webbrowser.open("http://127.0.0.1:43110", new=2)
+server.join()

--- a/start.py
+++ b/start.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python
 from multiprocessing import Process
+import sys
 import webbrowser
 import zeronet
 
-server = Process(target=zeronet.main)
-server.start()
-url = webbrowser.open("http://127.0.0.1:43110", new=2)
-server.join()
+def main():
+    browser_name = sys.argv.pop() if len(sys.argv) >= 2 else None
+    server = Process(target=zeronet.main)
+    server.start()
+    browser = webbrowser.get(browser_name)
+    url = browser.open("http://127.0.0.1:43110", new=2)
+    server.join()
+
+if __name__ == '__main__':
+    main()

--- a/zeronet.py
+++ b/zeronet.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 
-try:
-	from src import main
-	main.start()
-except Exception, err: # Prevent closing
-	import traceback
-	traceback.print_exc()
-	raw_input("-- Error happened, press enter to close --")
+def main():
+    try:
+    	from src import main
+    	main.start()
+    except Exception, err: # Prevent closing
+    	import traceback
+    	traceback.print_exc()
+    	raw_input("-- Error happened, press enter to close --")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This should resolve issue #17. By default running `python start.py` will launch the zeronet server in a subprocess then open the default browser. The user can also specify which browser to open. For example, `python start.py firefox`.