### PR TITLE
Y wrapperbug

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -222,7 +222,7 @@ class UiRequest:
 		ws = self.env.get("wsgi.websocket")
 		if ws:
 			wrapper_key = self.get["wrapper_key"]
-			# Find site by wraper_key
+			# Find site by wrapper_key
 			site = None
 			for site_check in self.server.sites.values():
 				if site_check.settings["wrapper_key"] == wrapper_key: site = site_check
@@ -236,7 +236,7 @@ class UiRequest:
 						site_check.websockets.remove(ui_websocket)
 				return "Bye."
 			else: # No site found by wrapper key
-				self.log.error("Wrapper key not found: %s" % wraper_key)
+				self.log.error("Wrapper key not found: %s" % wrapper_key)
 				return self.error403()
 		else:
 			start_response("400 Bad Request", []) 


### PR DESCRIPTION
There was a typo in which was attempting to log out the wrapper_key, but instead it was spelled "wraper_key".

The NameError in issue #35 is fixed by this:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/gevent/pywsgi.py", line 508, in handle_one_response
    self.run_application()
  File "/home/arthur/local/ZeroNet/src/Ui/UiServer.py", line 21, in run_application
    self.ws_handler.run_application()
  File "/home/arthur/local/ZeroNet/src/lib/geventwebsocket/handler.py", line 81, in run_application
    self.run_websocket()
  File "/home/arthur/local/ZeroNet/src/lib/geventwebsocket/handler.py", line 57, in run_websocket
    self.application(self.environ, lambda s, h: [])
  File "/home/arthur/local/ZeroNet/src/Ui/UiServer.py", line 49, in handleRequest
    return self.ui_request.route(path)
  File "/home/arthur/local/ZeroNet/src/Ui/UiRequest.py", line 41, in route
    return self.actionWebsocket()
  File "/home/arthur/local/ZeroNet/src/Ui/UiRequest.py", line 239, in actionWebsocket
    self.log.error("Wrapper key not found: %s" % wraper_key)
NameError: global name 'wraper_key' is not defined
```