### PR TITLE
Enabled meta viewport, to support Responsive Design.

### DIFF
--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -6,6 +6,7 @@
  <title>{title} - ZeroNet</title>
  <meta charset="utf-8">
  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+ <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <link rel="stylesheet" href="/uimedia/all.css" />
 </head>
 <body style="{body_style}">


### PR DESCRIPTION
Meta tags inside the iframe are largely ignored, to enable developers to build responsive applications, they need a viewport. Though many developers tweak the viewport setting, the one presented here is by-and-large the most commonly used, as it's simple and effective.