### PR TITLE
Add DNS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV HOME /root
 RUN apt-get update -y
 
 #Install ZeroNet deps
-RUN apt-get install msgpack-python python-gevent python-pip python-dev -y
+RUN apt-get install msgpack-python python-gevent python-pip python-dev python-dnspython -y
 RUN pip install msgpack-python --upgrade
 
 #Add Zeronet source

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Decentralized websites using Bitcoin crypto and the BitTorrent network - http://
 ## Features
  * Real-time updated sites
  * Namecoin .bit domains support
+ * DNS support
  * Easy to setup: unpack & run
  * Password-less [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) 
    based authorization: Your account is protected by same cryptography as your Bitcoin wallet
@@ -80,7 +81,7 @@ It downloads the latest version of ZeroNet then starts it automatically.
 #### Debian
 
 * `sudo apt-get update`
-* `sudo apt-get install msgpack-python python-gevent` 
+* `sudo apt-get install msgpack-python python-gevent python-dnspython` 
 * `wget https://github.com/HelloZeroNet/ZeroNet/archive/master.tar.gz`
 * `tar xvpfz master.tar.gz`
 * `cd ZeroNet-master`
@@ -90,14 +91,14 @@ It downloads the latest version of ZeroNet then starts it automatically.
 #### Other Linux or without root access
 * Check your python version using `python --version` if the returned version is not `Python 2.7.X` then try `python2` or `python2.7` command and use it from now
 * `wget https://bootstrap.pypa.io/get-pip.py` 
-* `python get-pip.py --user gevent msgpack-python`
+* `python get-pip.py --user gevent msgpack-python dnspython`
 * Start with `python zeronet.py`
 
 ### Mac
 
  * Install [brew](http://brew.sh/)
  * `brew install python`
- * `pip install gevent msgpack-python`
+ * `pip install gevent msgpack-python dnspython`
  * [Download](https://github.com/HelloZeroNet/ZeroNet/archive/master.zip), Unpack, run `python zeronet.py`
  
 ### Vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   #Install deps
   config.vm.provision "shell",
-      inline: "sudo apt-get install msgpack-python python-gevent python-pip python-dev -y"
+      inline: "sudo apt-get install msgpack-python python-gevent python-pip python-dev python-dnspython -y"
   config.vm.provision "shell",
       inline: "sudo pip install msgpack-python --upgrade"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gevent==1.0.1
 pyzmq==14.4.1
 msgpack-python==0.4.4
+dnspython==1.12.0

--- a/src/Config.py
+++ b/src/Config.py
@@ -121,6 +121,8 @@ class Config(object):
 		parser.add_argument('--use_openssl',	help='Use OpenSSL liblary for speedup', type='bool', choices=[True, False], default=use_openssl)
 		parser.add_argument('--ip_external',	help='External ip (tested on start if None)', metavar='ip')
 
+		parser.add_argument('--dns_server', 	help='DNS server', default='8.8.8.8', metavar='ip')
+
 		parser.add_argument('--coffeescript_compiler',	help='Coffeescript compiler for developing', default=coffeescript, metavar='executable_path')
 
 		parser.add_argument('--version', 	action='version', version='ZeroNet %s r%s' % (self.version, self.rev))


### PR DESCRIPTION
Add DNS support. This change require the additional dependency dnspython. Please add this to the Windows installing documentation (i have no windows to test).

Usage:
Simply add a new TXT record to your DNS zonefile on your nameservers:

```
subdomain        IN      TXT    "zero=1TaLk3zM7ZRskJvrh3ZNCDVGXvkJusPKQ"
```

The used DNS Server can be set with a additional startup option. 

I used the Zeroname plugin because a additional plugin will result in much redundant code.




