### PR TITLE
Created Zeroname-local plugin that use local namecoind for lookup

### DIFF
--- a/plugins/disabled-Zeroname-local/SiteManagerPlugin.py
+++ b/plugins/disabled-Zeroname-local/SiteManagerPlugin.py
@@ -1,0 +1,68 @@
+import logging, json, os, re, sys, time
+import gevent
+from Plugin import PluginManager
+from Config import config
+from Debug import Debug
+from domainLookup import lookupDomain
+
+allow_reload = False # No reload supported
+
+log = logging.getLogger("Zeroname-localPlugin")
+
+
+@PluginManager.registerTo("SiteManager")
+class SiteManagerPlugin(object):
+	def load(self):
+		super(SiteManagerPlugin, self).load()
+
+	# Checks if its a valid address
+	def isAddress(self, address):
+		if self.isDomain(address): 
+			return True
+		else:
+			return super(SiteManagerPlugin, self).isAddress(address)
+
+
+	# Return: True if the address is domain
+	def isDomain(self, address):
+		return re.match("(.*?)([A-Za-z0-9_-]+\.[A-Za-z0-9]+)$", address)
+
+
+	# Resolve domain
+	# Return: The address or None
+	def resolveDomain(self, domain):
+		return lookupDomain(domain)
+
+
+	# Return or create site and start download site files
+	# Return: Site or None if dns resolve failed
+	def need(self, address, all_file=True):
+		if self.isDomain(address): # Its looks like a domain
+			address_resolved = self.resolveDomain(address)
+			if address_resolved:
+				address = address_resolved
+			else:
+				return None
+		
+		return super(SiteManagerPlugin, self).need(address, all_file)
+
+
+	# Return: Site object or None if not found
+	def get(self, address):
+		if self.sites == None: # Not loaded yet
+			self.load()
+		if self.isDomain(address): # Its looks like a domain
+			address_resolved = self.resolveDomain(address)
+			if address_resolved: # Domain found
+				site = self.sites.get(address_resolved)
+				if site:
+					site_domain = site.settings.get("domain")
+					if site_domain != address:
+						site.settings["domain"] = address
+			else: # Domain not found
+				site = self.sites.get(address)
+
+		else: # Access by site address
+			site = self.sites.get(address)
+		return site
+

--- a/plugins/disabled-Zeroname-local/UiRequestPlugin.py
+++ b/plugins/disabled-Zeroname-local/UiRequestPlugin.py
@@ -1,0 +1,40 @@
+import re
+from Plugin import PluginManager
+
+@PluginManager.registerTo("UiRequest")
+class UiRequestPlugin(object):
+	def __init__(self, *args, **kwargs):
+		from Site import SiteManager
+		self.site_manager = SiteManager.site_manager
+		super(UiRequestPlugin, self).__init__(*args, **kwargs)
+
+
+	# Media request
+	def actionSiteMedia(self, path):
+		match = re.match("/media/(?P<address>[A-Za-z0-9]+\.[A-Za-z0-9\.]+)(?P<inner_path>/.*|$)", path)
+		if match: # Its a valid domain, resolve first
+			domain = match.group("address")
+			address = self.site_manager.resolveDomain(domain)
+			if address:
+				path = "/media/"+address+match.group("inner_path")
+		return super(UiRequestPlugin, self).actionSiteMedia(path) # Get the wrapper frame output
+
+
+	# Is mediarequest allowed from that referer
+	def isMediaRequestAllowed(self, site_address, referer):
+		referer_path = re.sub("http[s]{0,1}://.*?/", "/", referer).replace("/media", "") # Remove site address
+		referer_path = re.sub("\?.*", "", referer_path) # Remove http params
+
+		if self.isProxyRequest(): # Match to site domain
+			referer = re.sub("^http://zero[/]+", "http://", referer) # Allow /zero access
+			referer_site_address = re.match("http[s]{0,1}://(.*?)(/|$)", referer).group(1)
+		else: # Match to request path
+			referer_site_address = re.match("/(?P<address>[A-Za-z0-9\.]+)(?P<inner_path>/.*|$)", referer_path).group("address")
+
+		if referer_site_address == site_address: # Referer site address as simple address
+			return True
+		elif self.site_manager.resolveDomain(referer_site_address) == site_address: # Referer site address as dns
+			return True
+		else: # Invalid referer
+			return False
+

--- a/plugins/disabled-Zeroname-local/__init__.py
+++ b/plugins/disabled-Zeroname-local/__init__.py
@@ -1,0 +1,2 @@
+import UiRequestPlugin
+import SiteManagerPlugin

--- a/plugins/disabled-Zeroname-local/domainLookup.py
+++ b/plugins/disabled-Zeroname-local/domainLookup.py
@@ -1,0 +1,81 @@
+from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
+import time, json, os, sys, re, socket, json
+
+# Either returns domain's address or none if it doesn't exist
+# Supports subdomains and .bit on the end
+def lookupDomain(domain):
+	domain = domain.lower()
+	
+	#remove .bit on end
+	if domain[-4:] == ".bit":
+		domain = domain[0:-4]
+		
+	#check for subdomain
+	if domain.find(".") != -1:
+		subdomain = domain[0:domain.find(".")]
+		domain = domain[domain.find(".")+1:]
+	else:
+		subdomain = ""
+	
+	try:
+		domain_object = rpc.name_show("d/"+domain)
+	except:
+		#domain doesn't exist
+		return None
+	
+	domain_json = json.loads(domain_object['value'])
+	
+	try:
+		domain_address = domain_json["zeronet"][subdomain]
+	except:
+		#domain exists but doesn't have any zeronet value
+		return None
+	
+	return domain_address
+
+# Loading config...
+
+# Check whether platform is on windows or linux
+# On linux namecoin is installed under ~/.namecoin, while on on windows it is in %appdata%/Namecoin
+
+if sys.platform == "win32":
+    namecoin_location = os.getenv('APPDATA') + "/Namecoin/"
+else:
+    namecoin_location = os.path.expanduser("~/.namecoin/")
+
+# Getting rpc connect details
+namecoin_conf = open(namecoin_location + "namecoin.conf").read()
+
+# Connecting to RPC
+rpc_user = re.search("rpcuser=(.*)$", namecoin_conf, re.M).group(1)
+rpc_pass = re.search("rpcpassword=(.*)$", namecoin_conf, re.M).group(1)
+rpc_url = "http://%s:%s@127.0.0.1:8336" % (rpc_user, rpc_pass)
+
+rpc = AuthServiceProxy(rpc_url, timeout=60*5)
+
+"""
+while 1:
+	print "Waiting for new block",
+	sys.stdout.flush()
+	while 1:
+		try:
+			rpc = AuthServiceProxy(rpc_url, timeout=60*5)
+			if (int(rpc.getinfo()["blocks"]) > last_block): break
+			time.sleep(1)
+			rpc.waitforblock()
+			print "Found"
+			break # Block found
+		except socket.timeout: # Timeout
+			print ".",
+			sys.stdout.flush()
+		except Exception, err:
+			print "Exception", err.__class__, err
+			time.sleep(5)
+
+	last_block = int(rpc.getinfo()["blocks"])
+	for block_id in range(config["lastprocessed"]+1, last_block+1):
+		processBlock(block_id)
+
+	config["lastprocessed"] = last_block
+	open(config_path, "w").write(json.dumps(config, indent=2))
+"""


### PR DESCRIPTION
Reused Zeroname code, and swapped out the reolveDomain function. It now connects to namecoind directly using RPC and then run rpc.name_show() to find domain.

It might be a bit slow as there is no caching - it looks up the domain each time on the blockchain. 
I'm not sure how to handle the bitcoinrpc dependancy, so I have left that out.

Also, it is disabled by default. If it works well we might want to consider a "automatic" detection system - check if namecoin is installed, and if not fallback to hosted Zeroname. 