### PR TITLE
coffee.wsf: Encode the resulting file in UTF-8 without BOM

### DIFF
--- a/tools/coffee/coffee.wsf
+++ b/tools/coffee/coffee.wsf
@@ -82,10 +82,20 @@ function readUtf8(filename) {
 
 function writeUtf8(filename, text) {
 	var stream = new ActiveXObject("ADODB.Stream");
-	stream.Open();
 	stream.Type = 2; // Text
-	stream.Charset = 'utf-8';
+	stream.Charset = "utf-8";
+	stream.Open();
 	stream.WriteText(text);
+
+	stream.Position = 0;
+	stream.Type = 1; // Binary
+	stream.Position = 3;
+	var binary = stream.Read();
+	stream.Close();
+
+	stream.Open();
+	stream.Type = 1; // Binary
+	stream.Write(binary);
 	stream.SaveToFile(filename, 2);
 	stream.Close();
 }


### PR DESCRIPTION
It isn't recommended to encode the file with BOM