### PR TITLE
Remove ​invalid ​​​character from docker repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ It downloads the latest version of ZeroNet then starts it automatically.
 * Open http://127.0.0.1:43110/ in your browser
 
 ### Docker
-* `docker run -p 15441:15441 -p 43110:43110 nofish/zeronet​`
+* `docker run -p 15441:15441 -p 43110:43110 nofish/zeronet`
 * Open http://127.0.0.1:43110/ in your browser
 
 ## Current limitations


### PR DESCRIPTION
Running original Docker command:

```
$ docker run -p 15441:15441 -p 43110:43110 nofish/zeronet<200b>
Unable to find image 'nofish/zeronet​:latest' locally
repository name component must match "[a-z0-9](?:-*[a-z0-9])*(?:[._][a-z0-9](?:-*[a-z0-9])*)*"
```

With odd character removed:

```
$ docker run -p 15441:15441 -p 43110:43110 nofish/zeronet      
Unable to find image 'nofish/zeronet:latest' locally
latest: Pulling from nofish/zeronet
c63fb41c2213: Pull complete 
99fcaefe76ef: Pull complete 
5a4526e952f0: Pull complete 
...
```
