### PR TITLE
Fix error when opening menu if file size is null

### DIFF
--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -144,7 +144,10 @@ class UiWebsocketPlugin(object):
             else:
                 size = size_filetypes.get(extension, 0)
                 size_other -= size
-            percent = 100 * (float(size) / size_total)
+            if size_total == 0:
+                percent = 0
+            else:
+                percent = 100 * (float(size) / size_total)
             body.append(u"<li style='width: %.2f%%' class='%s back-%s' title='%s'></li>" % (percent, extension, color, extension))
 
         # Legend


### PR DESCRIPTION
@HelloZeroNet It fixes a division by 0
Or, does it makes more sense to not add the "li" at all if size is zero?