### PR TITLE
Disabled benchmarking in MultiUser

### DIFF
--- a/plugins/disabled-Multiuser/MultiuserPlugin.py
+++ b/plugins/disabled-Multiuser/MultiuserPlugin.py
@@ -152,6 +152,12 @@ class UiWebsocketPlugin(object):
             self.actionUserLoginForm(0)
 
     # Disable not Multiuser safe functions
+    def actionBenchmark(self, to, *args, **kwargs):
+        if not config.multiuser_local:
+            self.cmd("notification", ["info", "This function is disabled on this proxy"])
+        else:
+            return super(UiWebsocketPlugin, self).actionSiteDelete(to, *args, **kwargs)
+
     def actionSiteDelete(self, to, *args, **kwargs):
         if not config.multiuser_local:
             self.cmd("notification", ["info", "This function is disabled on this proxy"])


### PR DESCRIPTION
The Benchmarking function is CPU intensive, so someone could easily DOS
a proxy.

Pointed out in:
http://127.0.0.1:43110/Talk.ZeroNetwork.bit/?Topic:1_1LJP7tDoGnWNppUGJoNS8cJbmYTS1TecCC/Zero+proxies+vulnerability