### PR TITLE
Fix issue parsing @keyframes in css files

### DIFF
--- a/src/lib/cssvendor/cssvendor.py
+++ b/src/lib/cssvendor/cssvendor.py
@@ -3,7 +3,7 @@ import re
 
 def prefix(content):
     content = re.sub(
-        "@keyframes (.*? {.*?[^ ]})", "@keyframes \\1\n@-webkit-keyframes \\1\n@-moz-keyframes \\1\n",
+        "@keyframes (.*? {.*})", "@keyframes \\1\n@-webkit-keyframes \\1\n@-moz-keyframes \\1\n",
         content, flags=re.DOTALL
     )
     content = re.sub(


### PR DESCRIPTION
ZeroNet breaks css in the compilation / merge process under certain circumstances. This example will fail to compile a valid css file. 

    @keyframes flip {                                                                                                                                         
        0%   { transform: perspective(120px) rotateX(0deg) rotateY(0deg);}                                                                                 
        50%  { transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg)}                                                                                    
        100% { transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg);}                                                                         
    } 

It produces this css code:

    @keyframes flip {
        0%   { -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -moz-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -o-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -ms-transform: perspective(120px) rotateX(0deg) rotateY(0deg); transform: perspective(120px) rotateX(0deg) rotateY(0deg) ;}
    @-webkit-keyframes flip {
        0%   { -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -moz-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -o-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -ms-transform: perspective(120px) rotateX(0deg) rotateY(0deg); transform: perspective(120px) rotateX(0deg) rotateY(0deg) ;}
    @-moz-keyframes flip {
        0%   { -webkit-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -moz-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -o-transform: perspective(120px) rotateX(0deg) rotateY(0deg); -ms-transform: perspective(120px) rotateX(0deg) rotateY(0deg); transform: perspective(120px) rotateX(0deg) rotateY(0deg) ;}

        50%  { -webkit-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg); -moz-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg); -o-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg); -ms-transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg); transform: perspective(120px) rotateX(-180.1deg) rotateY(0deg) }
        100% { -webkit-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg); -moz-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg); -o-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg); -ms-transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg); transform: perspective(120px) rotateX(-180deg) rotateY(-179.9deg) ;}
    }

It stops processing the keyframe rule after the first percentage keyword and starts with the next vendor-prefix without closing the bracket, which causes the issue.

This seems to happen when there isn't an space character before the closing bracket in the percentage rules, caused by `{.*?[^ ]}`. Replacing the regular expression makes the trick.