### PR TITLE
Fix issue parsing @keyframes in css files

### DIFF
--- a/src/lib/cssvendor/cssvendor.py
+++ b/src/lib/cssvendor/cssvendor.py
@@ -3,7 +3,7 @@ import re
 
 def prefix(content):
     content = re.sub(
-        "@keyframes (.*? {.*?[^ ]})", "@keyframes \\1\n@-webkit-keyframes \\1\n@-moz-keyframes \\1\n",
+        "@keyframes (.*? {.*?}\s*})", "@keyframes \\1\n@-webkit-keyframes \\1\n@-moz-keyframes \\1\n",
         content, flags=re.DOTALL
     )
     content = re.sub(


### PR DESCRIPTION
This works better than #370.

However, there still is an issue here, if the original file already includes the prefixed version of the @keyframes it will generate them again and will be duplicated in the compiled css file.

It's not a priority as far as it compiles a valid css file, but maybe it's worth considering to remove this from the ZeroNet core and leave it to the web developer, tools such as css pre-processors already compile, merge and add the prefixes when needed.