### PR TITLE
Add tor and phantomjs dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,11 @@ data/*
 
 # Virtualenv
 env/*
+
+# Tor, downloaded automatically
+tools/tor/data
+tools/tor/*exe
+tools/tor/*dll
+
+# PhantomJS, downloaded manually for unit tests
+tools/phantomjs


### PR DESCRIPTION
I think this is right now.