### PR TITLE
Added "allow-same-origin" flag to iframe sandbox to allow for DASH videos

### DIFF
--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -55,7 +55,7 @@ if (window.opener && window.stop) window.stop()
 
 
 <!-- Site Iframe -->
-<iframe src='about:blank' id='inner-iframe' sandbox="allow-forms allow-scripts allow-top-navigation allow-popups {sandbox_permissions}"></iframe>
+<iframe src='about:blank' id='inner-iframe' sandbox="allow-forms allow-scripts allow-top-navigation allow-popups allow-same-origin {sandbox_permissions}"></iframe>
 
 <!-- Site info -->
 <script>


### PR DESCRIPTION
As per yesterday's IRC conversation. Since larger than 1MB files are not supported yet on ZeroNet, made a change for dash.js to work with ZeroNet's IFRAME. Otherwise the browser does not allow reading the video segment files.