### PR TITLE
Fix file permissions

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 # Included modules
 import os
 import sys
+import stat
 import time
 import logging
 
@@ -33,8 +34,10 @@ if not os.path.isdir(config.data_dir):
     os.mkdir(config.data_dir)
 if not os.path.isfile("%s/sites.json" % config.data_dir):
     open("%s/sites.json" % config.data_dir, "w").write("{}")
+    os.chmod("%s/sites.json" % config.data_dir, stat.S_IRUSR | stat.S_IWUSR)
 if not os.path.isfile("%s/users.json" % config.data_dir):
     open("%s/users.json" % config.data_dir, "w").write("{}")
+    os.chmod("%s/users.json" % config.data_dir, stat.S_IRUSR | stat.S_IWUSR)
 
 # Setup logging
 if config.action == "main":

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import socket
 import struct
 import re
@@ -10,6 +11,7 @@ import base64
 
 def atomicWrite(dest, content, mode="w"):
     try:
+        permissions = stat.S_IMODE(os.lstat(dest).st_mode)
         with open(dest + "-new", mode) as f:
             f.write(content)
             f.flush()
@@ -18,6 +20,7 @@ def atomicWrite(dest, content, mode="w"):
             os.rename(dest + "-old", dest + "-old-%s" % time.time())
         os.rename(dest, dest + "-old")
         os.rename(dest + "-new", dest)
+        os.chmod(dest, permissions)
         os.unlink(dest + "-old")
         return True
     except Exception, err:


### PR DESCRIPTION
I noticed that the files `data/users.json` and `data/sites.json` have the permissions `644` which means everybody can read them, even if they contain private keys. So I changed these files' permissions to `600` to ensure that only their owner can read them (as ssh does for its private keys).
I also modified the function `atomicWrite` so that the file permissions are preserved (they were reset to `644` each time). 