### PR TITLE
ZeroNet Sharing Protocol Transport Abstraction

### DIFF
--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -5,6 +5,7 @@ from Plugin import PluginManager
 from Peer import Peer
 from util import helper
 from Crypt import CryptRsa
+from Config import config
 
 allow_reload = False  # No source reload supported in this plugin
 time_full_announced = {}  # Tracker address: Last announced all site to tracker
@@ -83,7 +84,10 @@ class SitePlugin(object):
             tracker_ip, tracker_port = tracker_address.split(":")
             tracker = Peer(tracker_ip, tracker_port, connection_server=self.connection_server)
             connection_pool[tracker_address] = tracker
+
+        print(request)
         res = tracker.request("announce", request)
+        print(res)
 
         if not res or "peers" not in res:
             self.log.debug("Announce to %s failed: %s" % (tracker_address, res))

--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -83,7 +83,6 @@ class SitePlugin(object):
             tracker_ip, tracker_port = tracker_address.split(":")
             tracker = Peer(tracker_ip, tracker_port, connection_server=self.connection_server)
             connection_pool[tracker_address] = tracker
-
         res = tracker.request("announce", request)
 
         if not res or "peers" not in res:

--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -83,12 +83,8 @@ class SitePlugin(object):
             tracker_ip, tracker_port = tracker_address.split(":")
             tracker = Peer(tracker_ip, tracker_port, connection_server=self.connection_server)
             connection_pool[tracker_address] = tracker
-  
-        print(request)
 
         res = tracker.request("announce", request)
-
-        print(res)
 
         if not res or "peers" not in res:
             self.log.debug("Announce to %s failed: %s" % (tracker_address, res))

--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -45,9 +45,12 @@ class SitePlugin(object):
 
         s = time.time()
 
-        need_types = ["ip4"]
-        if self.connection_server and self.connection_server.tor_manager and self.connection_server.tor_manager.enabled:
-            need_types.append("onion")
+        if config.onion_only:
+            need_types = ["onion"]
+        else:
+            need_types = ["ip4"]
+            if self.connection_server and self.connection_server.tor_manager and self.connection_server.tor_manager.enabled:
+                need_types.append("onion")
 
         if mode == "start" or mode == "more":  # Single: Announce only this site
             sites = [self]
@@ -80,7 +83,12 @@ class SitePlugin(object):
             tracker_ip, tracker_port = tracker_address.split(":")
             tracker = Peer(tracker_ip, tracker_port, connection_server=self.connection_server)
             connection_pool[tracker_address] = tracker
+  
+        print(request)
+
         res = tracker.request("announce", request)
+
+        print(res)
 
         if not res or "peers" not in res:
             self.log.debug("Announce to %s failed: %s" % (tracker_address, res))

--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -84,10 +84,7 @@ class SitePlugin(object):
             tracker_ip, tracker_port = tracker_address.split(":")
             tracker = Peer(tracker_ip, tracker_port, connection_server=self.connection_server)
             connection_pool[tracker_address] = tracker
-
-        print(request)
         res = tracker.request("announce", request)
-        print(res)
 
         if not res or "peers" not in res:
             self.log.debug("Announce to %s failed: %s" % (tracker_address, res))

--- a/src/Config.py
+++ b/src/Config.py
@@ -170,6 +170,10 @@ class Config(object):
         self.parser.add_argument('--tor', help='enable: Use only for Tor peers, always: Use Tor for every connection', choices=["disable", "enable", "always"], default='enable')
         self.parser.add_argument('--tor_controller', help='Tor controller address', metavar='ip:port', default='127.0.0.1:9051')
         self.parser.add_argument('--tor_proxy', help='Tor proxy address', metavar='ip:port', default='127.0.0.1:9050')
+        self.parser.add_argument("--onion_only", help='Discriminates against ipv4 peers and trackers.',
+                                 type='bool', choices=[True, False], default=False)
+        self.parser.add_argument("--pex_only", help='Discriminates against non-zeronet peers and trackers.',
+                                 type='bool', choices=[True, False], default=False)
 
         self.parser.add_argument('--version', action='version', version='ZeroNet %s r%s' % (self.version, self.rev))
 

--- a/src/Peer/Peer.py
+++ b/src/Peer/Peer.py
@@ -240,10 +240,11 @@ class Peer(object):
             return False
         added = 0
         # Ip4
-        for peer in res.get("peers", []):
-            address = helper.unpackAddress(peer)
-            if site.addPeer(*address):
-                added += 1
+        if not config.pex_only:
+            for peer in res.get("peers", []):
+                address = helper.unpackAddress(peer)
+                if site.addPeer(*address):
+                    added += 1
         # Onion
         for peer in res.get("peers_onion", []):
             address = helper.unpackOnionAddress(peer)

--- a/src/Peer/Peer.py
+++ b/src/Peer/Peer.py
@@ -240,7 +240,7 @@ class Peer(object):
             return False
         added = 0
         # Ip4
-        if not config.pex_only:
+        if not config.onion_only:
             for peer in res.get("peers", []):
                 address = helper.unpackAddress(peer)
                 if site.addPeer(*address):

--- a/src/Site/Site.py
+++ b/src/Site/Site.py
@@ -718,7 +718,7 @@ class Site(object):
             my_peer_id = self.connection_server.peer_id
 
             # Type of addresses they can reach me
-            if self.connection_server.port_opened:
+            if self.connection_server.port_opened and not config.onion_only:
                 add_types.append("ip4")
             if self.connection_server.tor_manager.enabled and self.connection_server.tor_manager.start_onions:
                 add_types.append("onion")

--- a/src/Site/Site.py
+++ b/src/Site/Site.py
@@ -701,6 +701,10 @@ class Site(object):
             trackers = [tracker for tracker in trackers if not tracker.startswith("udp://")]
         if self.connection_server and not self.connection_server.tor_manager.enabled:
             trackers = [tracker for tracker in trackers if ".onion" not in tracker]
+        if config.onion_only:
+            trackers = [tracker for tracker in trackers if ".onion" in tracker]
+        if config.pex_only:
+            trackers = [tracker for tracker in trackers if tracker.startswith("zero://")]
 
         if mode == "update" or mode == "more":  # Only announce on one tracker, increment the queried tracker id
             self.last_tracker_id += 1


### PR DESCRIPTION
Self-explanatory.

libzeronet will not support ipv4 (even through Tor exit nodes) nor BitTorrent trackers for hardened security and improved decentralization.
