### PR TITLE
Update Dockerfile base image to ubuntu 16.04 LTS and add Tor support to it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER Felix Imobersteg <felix@whatwedo.ch>
 
@@ -9,17 +9,20 @@ ENV HOME /root
 #Install ZeroNet
 RUN \
     apt-get update -y; \
-    apt-get -y install msgpack-python python-gevent python-pip python-dev; \
+    apt-get -y install msgpack-python python-gevent python-pip python-dev tor; \
     pip install msgpack-python --upgrade; \
     apt-get clean -y; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    echo "ControlPort 9051" >> /etc/tor/torrc; \
+    echo "CookieAuthentication 1" >> /etc/tor/torrc
+    
 
 #Add Zeronet source
 ADD . /root
 VOLUME /root/data
 
 #Set upstart command
-CMD cd /root && python zeronet.py --ui_ip 0.0.0.0
+CMD cd /root && /etc/init.d/tor start && python zeronet.py --ui_ip 0.0.0.0
 
 #Expose ports
 EXPOSE 43110


### PR DESCRIPTION
In order to keep the Dockerfile simple, needed opotions have been appended to package provided torrc file and the /etc/init.d/tor script is used to start tor. If further customisation is desired, a wrapper script should be created to have further control on the startup. This would allow things like specifying external (tor) proxies and disable tor startup in those situations.