### PR TITLE
Update Dockerfile base image to ubuntu 16.04 LTS and add Tor support to it (disabled by default).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ RUN \
 ADD . /root
 VOLUME /root/data
 
+#Control if Tor proxy is started
+ENV ENABLE_TOR false
+
 #Set upstart command
-CMD cd /root && /etc/init.d/tor start && python zeronet.py --ui_ip 0.0.0.0
+CMD cd /root && (! ${ENABLE_TOR} || /etc/init.d/tor start) && python zeronet.py --ui_ip 0.0.0.0
 
 #Expose ports
 EXPOSE 43110

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER Felix Imobersteg <felix@whatwedo.ch>
 
@@ -9,17 +9,20 @@ ENV HOME /root
 #Install ZeroNet
 RUN \
     apt-get update -y; \
-    apt-get -y install msgpack-python python-gevent python-pip python-dev; \
+    apt-get -y install msgpack-python python-gevent python-pip python-dev tor; \
     pip install msgpack-python --upgrade; \
     apt-get clean -y; \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    echo "ControlPort 9051" >> /etc/tor/torrc; \
+    echo "CookieAuthentication 1" >> /etc/tor/torrc
+    
 
 #Add Zeronet source
 ADD . /root
 VOLUME /root/data
 
 #Set upstart command
-CMD cd /root && python zeronet.py --ui_ip 0.0.0.0
+CMD cd /root && /etc/init.d/tor start && python zeronet.py --ui_ip 0.0.0.0
 
 #Expose ports
 EXPOSE 43110

--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ It downloads the latest version of ZeroNet then starts it automatically.
 
 ### [Docker](https://www.docker.com/)
 * `docker run -d -v <local_data_folder>:/root/data -p 15441:15441 -p 43110:43110 nofish/zeronet`
+* This Docker image includes the Tor proxy, which is disabled by default. Beware that some
+hosting providers may not allow you running Tor in their servers. If you want to enable it,
+set `ENABLE_TOR` environment variable to `true` (Default: `false`). E.g.:
+
+ `docker run -d -e "ENABLE_TOR=true" -v <local_data_folder>:/root/data -p 15441:15441 -p 43110:43110 nofish/zeronet`
 * Open http://127.0.0.1:43110/ in your browser
 
 ### [Virtualenv](https://virtualenv.readthedocs.org/en/latest/)


### PR DESCRIPTION
The base Ubuntu image has been upgraded to the current LTS release (16.04) and tor support has been added to the Docker image. Tor is disabled by default as it may not be allowed by different hosting providers. In order to enable it, just set `ENABLE_TOR` environment variable to `true` when executing `docker run` 