### PR TITLE
Update UiRequest.py

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -351,6 +351,8 @@ class UiRequest(object):
                         DebugMedia.merge(file_path)
                 if os.path.isfile(file_path):  # File exits
                     return self.actionFile(file_path)
+                elif os.path.isdir(file_path): # If this is actually a folder, add "/" and redirect
+                    return self.actionRedirect("./{0}/".format(path_parts["inner_path"].split("/")[-1]))
                 else:  # File not exits, try to download
                     site = SiteManager.site_manager.need(address, all_file=False)
                     result = site.needFile(path_parts["inner_path"], priority=5)  # Wait until file downloads


### PR DESCRIPTION
Fixed a bug where a lack of a trailing slash in every url caused zeronet to fail to load the page, even if it existed.

For example, if you go to http://127.0.0.1:43110/1CiDoBP8RiWziqiBGEd8tQMy66A6fmnw2V/big/docs, the page fails to load. However, if you go to http://127.0.0.1:43110/1CiDoBP8RiWziqiBGEd8tQMy66A6fmnw2V/big/docs/, it loads fine.

As far as I can tell, everything now works with this patch but it seems a little inelegant. When I got to such a url, the screen flashes for a second before redirecting. It would be better if it were instantaneous.