### PR TITLE
service should listen only at localhost by default (docker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ It downloads the latest version of ZeroNet then starts it automatically.
 * Open http://127.0.0.1:43110/ in your browser
 
 ### [Docker](https://www.docker.com/)
-* `docker run -d -v <local_data_folder>:/root/data -p 15441:15441 -p 43110:43110 nofish/zeronet`
+* `docker run -d -v <local_data_folder>:/root/data -p 15441:15441 -p 127.0.0.1:43110:43110 nofish/zeronet`
 * This Docker image includes the Tor proxy, which is disabled by default. Beware that some
 hosting providers may not allow you running Tor in their servers. If you want to enable it,
 set `ENABLE_TOR` environment variable to `true` (Default: `false`). E.g.:
 
- `docker run -d -e "ENABLE_TOR=true" -v <local_data_folder>:/root/data -p 15441:15441 -p 43110:43110 nofish/zeronet`
+ `docker run -d -e "ENABLE_TOR=true" -v <local_data_folder>:/root/data -p 15441:15441 -p 127.0.0.1:43110:43110 nofish/zeronet`
 * Open http://127.0.0.1:43110/ in your browser
 
 ### [Virtualenv](https://virtualenv.readthedocs.org/en/latest/)


### PR DESCRIPTION
If we expose the service to all interfaces (with 43110:43110 port mapping), it'll be reachable from anywhere (from where the box can be reached), and may impersonate the owner of the service

Moreover, the firewall setup is not straightforward for beginners, as docker sets up NAT rules to expose the services, so it cannot be just dropped in the filter/INPUT chain.