### PR TITLE
allow private ip ranges in socks proxy

### DIFF
--- a/src/Test/TestIP.py
+++ b/src/Test/TestIP.py
@@ -15,3 +15,5 @@ class TestIP:
         assert not is_private_address('127.a.15.1')
         assert not is_private_address('10.10.15.asd')
         assert not is_private_address("google.com")
+        assert not is_private_address("10.0x10.0.1")
+        assert not is_private_address("127.\x00.0.1")

--- a/src/Test/TestIP.py
+++ b/src/Test/TestIP.py
@@ -1,0 +1,17 @@
+import pytest
+
+from util.IP import is_private_address
+
+@pytest.mark.usefixtures("resetSettings")
+class TestIP:
+
+    def testPrivateRangeAcceptable(self):
+        assert is_private_address("127.0.0.1")
+        assert is_private_address("127.84.2.1")
+        assert is_private_address("10.55.1.56")
+
+    def testPrivateRangeUnacceptable(self):
+        assert not is_private_address('10.1111.15.1')
+        assert not is_private_address('127.a.15.1')
+        assert not is_private_address('10.10.15.asd')
+        assert not is_private_address("google.com")

--- a/src/util/IP.py
+++ b/src/util/IP.py
@@ -1,4 +1,4 @@
-
+import string
 
 def is_private_address(ip):
     """
@@ -6,5 +6,12 @@ def is_private_address(ip):
     """
     if isinstance(ip, tuple):
         ip = ip[0]
-    prefix = ip.split(".")[0]
+    split = ip.split(".")
+    if len(split) != 4:
+        return False
+    for part in split:
+        for c in part:
+            if c not in string.digits:
+                return False
+    prefix = split[0]
     return prefix in ['127', '10']

--- a/src/util/IP.py
+++ b/src/util/IP.py
@@ -1,0 +1,10 @@
+
+
+def is_private_address(ip):
+    """
+    :return True if this ip address is on a private address range:
+    """
+    if isinstance(ip, tuple):
+        ip = ip[0]
+    prefix = ip.split(".")[0]
+    return prefix in ['127', '10']

--- a/src/util/IP.py
+++ b/src/util/IP.py
@@ -9,9 +9,14 @@ def is_private_address(ip):
     split = ip.split(".")
     if len(split) != 4:
         return False
-    for part in split:
-        for c in part:
-            if c not in string.digits:
+    try:
+        for part in split:
+            if int(part) < 0:
                 return False
+            if int(part) > 255:
+                return False
+            
+    except:
+        return False
     prefix = split[0]
     return prefix in ['127', '10']

--- a/src/util/SocksProxy.py
+++ b/src/util/SocksProxy.py
@@ -1,10 +1,10 @@
 import socket
 
 from lib.PySocks import socks
-
+from util.IP import is_private_address
 
 def create_connection(address, timeout=None, source_address=None):
-    if address == "127.0.0.1":
+    if is_private_address(address):
         sock = socket.socket_noproxy(socket.AF_INET, socket.SOCK_STREAM)
         sock.connect(address)
     else:


### PR DESCRIPTION
this adds checks for 127.0.0.0/8 and 10.0.0.0/8 and treats them as directly connectable when using socks proxy.
