### PR TITLE
Add allow-same-origin to sandbox iframe

### DIFF
--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -55,7 +55,7 @@ if (window.opener && window.stop) window.stop()
 
 
 <!-- Site Iframe -->
-<iframe src='about:blank' id='inner-iframe' sandbox="allow-forms allow-scripts allow-top-navigation allow-popups {sandbox_permissions}"></iframe>
+<iframe src='about:blank' id='inner-iframe' sandbox="allow-forms allow-scripts allow-top-navigation allow-popups allow-same-origin {sandbox_permissions}"></iframe>
 
 <!-- Site info -->
 <script>


### PR DESCRIPTION
Allow access to methods of `window.parent.location` like `hash` or `query`.