### PR TITLE
Serve Site-Specific Favicon

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -55,8 +55,6 @@ class UiRequest(object):
 
         if path == "/":
             return self.actionIndex()
-        elif path.endswith("favicon.ico"):
-            return self.actionFile("src/Ui/media/img/favicon.ico")
         # Media
         elif path.startswith("/uimedia/"):
             return self.actionUiMedia(path)
@@ -198,6 +196,10 @@ class UiRequest(object):
                 (not site.getReachableBadFiles() or site.settings["own"])
             ):  # Its downloaded or own
                 title = site.content_manager.contents["content.json"]["title"]
+                try:
+                    favicon = site.content_manager.contents["content.json"]["favicon"]
+                except KeyError:
+                    favicon = "./uimedia/img/favicon.ico"
             else:
                 title = "Loading %s..." % address
                 site = SiteManager.site_manager.need(address)  # Start download site
@@ -206,13 +208,13 @@ class UiRequest(object):
                     return False
 
             self.sendHeader(extra_headers=extra_headers[:])
-            return iter([self.renderWrapper(site, path, inner_path, title, extra_headers)])
+            return iter([self.renderWrapper(site, path, inner_path, title, favicon, extra_headers)])
             # Dont know why wrapping with iter necessary, but without it around 100x slower
 
         else:  # Bad url
             return False
 
-    def renderWrapper(self, site, path, inner_path, title, extra_headers):
+    def renderWrapper(self, site, path, inner_path, title, favicon, extra_headers):
         file_inner_path = inner_path
         if not file_inner_path:
             file_inner_path = "index.html"  # If inner path defaults to index.html
@@ -272,6 +274,7 @@ class UiRequest(object):
             file_inner_path=re.escape(file_inner_path),
             address=site.address,
             title=cgi.escape(title, True),
+            favicon=favicon,
             body_style=body_style,
             meta_tags=meta_tags,
             query_string=re.escape(query_string),

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -190,6 +190,7 @@ class UiRequest(object):
                 return self.error403("Ajax request not allowed to load wrapper")  # No ajax allowed on wrapper
 
             site = SiteManager.site_manager.get(address)
+            favicon = ""
 
             if (
                 site and site.content_manager.contents.get("content.json") and
@@ -197,9 +198,10 @@ class UiRequest(object):
             ):  # Its downloaded or own
                 title = site.content_manager.contents["content.json"]["title"]
                 try:
-                    favicon = site.content_manager.contents["content.json"]["favicon"]
+                    siteFavicon = site.content_manager.contents["content.json"]["favicon"]
+                    favicon = "<link rel=\"icon\" href=\"/" + address + "/" + siteFavicon + "\">"
                 except KeyError:
-                    favicon = "./uimedia/img/favicon.ico"
+                    self.log.warn("Site lacks a favicon. Site: %s" % address)
             else:
                 title = "Loading %s..." % address
                 site = SiteManager.site_manager.need(address)  # Start download site
@@ -211,6 +213,9 @@ class UiRequest(object):
             return iter([self.renderWrapper(site, path, inner_path, title, favicon, extra_headers)])
             # Dont know why wrapping with iter necessary, but without it around 100x slower
 
+        # if the browser requests a favicon without an address in the path, send the default
+        elif path.endswith("favicon.ico"):
+            return self.actionFile("src/Ui/media/img/favicon.ico")
         else:  # Bad url
             return False
 

--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -4,7 +4,7 @@
 <html>
 <head>
  <title>{title} - ZeroNet</title>
- <link rel="icon" href="{favicon}">
+ {favicon}
  <meta charset="utf-8" />
  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
  <link rel="stylesheet" href="/uimedia/all.css?rev={rev}" />

--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -4,6 +4,7 @@
 <html>
 <head>
  <title>{title} - ZeroNet</title>
+ <link rel="icon" href="{favicon}">
  <meta charset="utf-8" />
  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
  <link rel="stylesheet" href="/uimedia/all.css?rev={rev}" />


### PR DESCRIPTION
Serve either the standard ZeroNet (icon](https://github.com/HelloZeroNet/ZeroNet/blob/master/src/Ui/media/img/favicon.ico) or an image referenced in `content.json` (example):

``` json
"title": "foo.bit",
"favicon": "1CLJpP511DDvMsrkdxufodHvLfZZdTtckr/favicon.png"
```
- [x] Simplify relative path resolution of favicon
- [x] Create a PR for "readthedocs" documentation

I'd like to create an associated PR for the documentation site before merging this in.

For some reason including the site address in the favicon path appears to be required...would love suggestions on allowing the path to look like its based from the site root directory:

``` json
"favicon": "favicon.png"
```
