### PR TITLE
Update README.md to include work-around for LSOpenURLsWithRole() errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Decentralized websites using Bitcoin crypto and the BitTorrent network - https:/
   * [Linux 32bit](https://github.com/HelloZeroNet/ZeroBundle/raw/master/dist/ZeroBundle-linux32.tar.gz)
 * Unpack anywhere
 * Run `ZeroNet.cmd` (win), `ZeroNet(.app)` (osx), `ZeroNet.sh` (linux)
+* On OSX you may need to make the application executable via `chmod +x ZeroNet.app`
 
 If you get "classic environment no longer supported" error on OS X: Open a Terminal window and drop ZeroNet.app on it
 


### PR DESCRIPTION
I downloaded the Mac bundle, unzipped, moved into directory.

I ran `open ZeroNet.app`.  An application icon briefly appeared on the dock, and then disappeared.

LSOpenURLsWithRole() failed with error -10810 for the file /Users/ju/Downloads/tmp/ZeroBundle/ZeroNet.app.

After googling around, it turns out you have to make the file executable via:

`chmod +x ZeroNet.app`

It would probably help others and save time to have this in the docs.