### PR TITLE
Add X-Frame-Options header

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -144,6 +144,7 @@ class UiRequest(object):
         headers.append(("Keep-Alive", "max=25, timeout=30"))
         if content_type != "text/html":
             headers.append(("Access-Control-Allow-Origin", "*"))  # Allow json access on non-html files
+        headers.append(("X-Frame-Options", "SAMEORIGIN"))
         # headers.append(("Content-Security-Policy", "default-src 'self' data: 'unsafe-inline' ws://127.0.0.1:* http://127.0.0.1:* wss://tracker.webtorrent.io; sandbox allow-same-origin allow-top-navigation allow-scripts"))  # Only local connections
         if self.env["REQUEST_METHOD"] == "OPTIONS":
             # Allow json access


### PR DESCRIPTION
**Partially** fixed #711

Save this file below as `zeronet.html`:
```html
Escape and Seed
<iframe id="an-iframe" src="about:blank"></iframe>
<script>
document.getElementById("an-iframe").src = "http://127.0.0.1:43110/13Lo9wpxbogHdaTQ9rGZruu9MJZnigzU3B/"; // EmojiDay site
// or any site that haven't benn saved on your computer
</script>
```
Start `python -m SimpleHTTPServer` and go to `http://127.0.0.1:8000/zeronet.html`
The script inside the `iframe` will **escape** and redirect you to seed EmojiDay site.

With `X-Frame-Options: SAMEORIGIN` header, framing will be denied by the browser.
```
GET http://127.0.0.1:8000/zeronet.html
GET http://127.0.0.1:43110/13Lo9wpxbogHdaTQ9rGZruu9MJZnigzU3B/

Load denied by X-Frame-Options:
http://127.0.0.1:43110/13Lo9wpxbogHdaTQ9rGZruu9MJZnigzU3B/ does not permit cross-origin framing.
```

However, ZeroNet **still seeds** that site even when the inner iframe is not loaded by the browser. (Issue #742)