### PR TITLE
TorManager.send(): read until repsonse terminator.

### DIFF
--- a/src/Tor/TorManager.py
+++ b/src/Tor/TorManager.py
@@ -239,10 +239,12 @@ class TorManager:
         if not conn:
             conn = self.conn
         self.log.debug("> %s" % cmd)
+        back = ""
         for retry in range(2):
             try:
                 conn.sendall("%s\r\n" % cmd)
-                back = conn.recv(1024 * 64).decode("utf8", "ignore")
+                while not back.endswith("250 OK\r\n"):
+                    back += conn.recv(1024 * 64).decode("utf8", "ignore")
                 break
             except Exception, err:
                 self.log.error("Tor send error: %s, reconnecting..." % err)


### PR DESCRIPTION
Tor command responses terminate with "250 OK\r\n" so we have to read
until that sequence is encountered.

The previous implementation is racy: after sending a command it would
accept whatever that is found on the socket as its response, no matter
if it is correctly terminated or not.

This commit fixes: https://github.com/HelloZeroNet/ZeroNet/issues/756