### PR TITLE
Make the cmd launcher "silent" and not stick around(fix for win10)

### DIFF
--- a/plugins/Trayicon/TrayiconPlugin.py
+++ b/plugins/Trayicon/TrayiconPlugin.py
@@ -139,10 +139,10 @@ class ActionsPlugin(object):
 
         return u"""
             @echo off
-            chcp 65001
+            chcp 65001 > nul
             set PYTHONIOENCODING=utf-8
             cd /D \"%s\"
-            %s
+            start "" %s
         """ % (cwd, cmd)
 
     def isAutorunEnabled(self):


### PR DESCRIPTION
The codepage changer was outputing a short msg, also waiting for the exe, this way it should start it and go away. 