### PR TITLE
Rename SiteStorage.list to SiteStorage.walk

### DIFF
--- a/plugins/Mute/MutePlugin.py
+++ b/plugins/Mute/MutePlugin.py
@@ -36,7 +36,7 @@ class UiWebsocketPlugin(object):
             if not site:
                 continue
             dir_inner_path = helper.getDirname(row["inner_path"])
-            for file_name in site.storage.list(dir_inner_path):
+            for file_name in site.storage.walk(dir_inner_path):
                 if action == "remove":
                     site.storage.onUpdated(dir_inner_path + file_name, False)
                 else:

--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -458,7 +458,7 @@ class ContentManager(object):
             ignored = True
             self.log.error("- [ERROR] Only ascii encoded directories allowed: %s" % dir_inner_path)
 
-        for file_relative_path in self.site.storage.list(dir_inner_path):
+        for file_relative_path in self.site.storage.walk(dir_inner_path):
             file_name = helper.getFilename(file_relative_path)
 
             ignored = optional = False

--- a/src/Site/SiteStorage.py
+++ b/src/Site/SiteStorage.py
@@ -202,7 +202,7 @@ class SiteStorage(object):
             raise err
 
     # List files from a directory
-    def list(self, dir_inner_path):
+    def walk(self, dir_inner_path):
         directory = self.getPath(dir_inner_path)
         for root, dirs, files in os.walk(directory):
             root = root.replace("\\", "/")
@@ -212,6 +212,11 @@ class SiteStorage(object):
                     yield root_relative_path + "/" + file_name
                 else:
                     yield file_name
+
+    # list directories in a directory
+    def list(self, dir_inner_path):
+        directory = self.getPath(dir_inner_path)
+        return os.listdir(directory)
 
     # Site content updated
     def onUpdated(self, inner_path, file=None):

--- a/src/Test/TestSiteStorage.py
+++ b/src/Test/TestSiteStorage.py
@@ -3,11 +3,20 @@ import pytest
 
 @pytest.mark.usefixtures("resetSettings")
 class TestSiteStorage:
+    def testWalk(self, site):
+        # Rootdir
+        walk_root = list(site.storage.walk(""))
+        assert "content.json" in walk_root
+        assert "css/all.css" in walk_root
+
+        # Subdir
+        assert list(site.storage.walk("data-default")) == ["data.json", "users/content-default.json"]
+
     def testList(self, site):
         # Rootdir
         list_root = list(site.storage.list(""))
         assert "content.json" in list_root
-        assert "css/all.css" in list_root
+        assert "css/all.css" not in list_root
 
         # Subdir
-        assert list(site.storage.list("data-default")) == ["data.json", "users/content-default.json"]
+        assert list(site.storage.list("data-default")) == ["data.json", "users"]

--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -37,7 +37,7 @@ class UiWebsocket(object):
             "channelJoinAllsite", "serverUpdate", "serverPortcheck", "serverShutdown", "certSet", "configSet",
             "actionPermissionAdd", "actionPermissionRemove"
         )
-        self.async_commands = ("fileGet", "fileList")
+        self.async_commands = ("fileGet", "fileList", "dirList")
 
     # Start listener loop
     def start(self):
@@ -520,6 +520,10 @@ class UiWebsocket(object):
 
     # List files in directory
     def actionFileList(self, to, inner_path):
+        return self.response(to, list(self.site.storage.walk(inner_path)))
+
+    # List directories in a directory
+    def actionDirList(self, to, inner_path):
         return self.response(to, list(self.site.storage.list(inner_path)))
 
     # Sql query


### PR DESCRIPTION
also, add SiteStorage.list as non-recursive
directory listing (`os.listdir`)

I've got a use case for listing the contents of a directory (non-recursively) and the nomenclature works better with 'list' (which is what it's actually doing) while the pre-existing 'list' function is actually performing a 'walk'.

I've renamed 'list' to 'walk' (to make more sense) and added 'list' for a single directory.