### PR TITLE
Root content.json "signers"  field as a list

### DIFF
--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -631,7 +631,7 @@ class ContentManager(object):
         valid_signers = []
         if inner_path == "content.json":  # Root content.json
             if "content.json" in self.contents and "signers" in self.contents["content.json"]:
-                valid_signers += self.contents["content.json"]["signers"].keys()
+                valid_signers += self.contents["content.json"]["signers"][:]
         else:
             rules = self.getRules(inner_path, content)
             if rules and "signers" in rules:


### PR DESCRIPTION
Changed this assignment to have the "signers" field in root's content.json as a list and not as a dictionary to mantain uniformity with "includes" "signers" field and for not having a dict with empty values.