### PR TITLE
fix issue #936

### DIFF
--- a/src/Debug/DebugMedia.py
+++ b/src/Debug/DebugMedia.py
@@ -85,7 +85,7 @@ def merge(merged_path):
                     return False  # No coffeescript compiler, skip this file
 
                 # Replace / with os separators and escape it
-                file_path_escaped = helper.shellquote(os.path.join(*file_path.split("/")))
+                file_path_escaped = helper.shellquote(file_path.replace(os.path.sep, "/"))
 
                 if "%s" in config.coffeescript_compiler:  # Replace %s with coffeescript file
                     command = config.coffeescript_compiler % file_path_escaped


### PR DESCRIPTION
os.path.join(*file_path.split("/")) construction drops leading slash from string thus making absolute path relative. It leads into problems in case if data_dir differs from directory where is zeronet installed.