### PR TITLE
fix incorrect variable order in file_path.replace

### DIFF
--- a/src/Debug/DebugMedia.py
+++ b/src/Debug/DebugMedia.py
@@ -85,7 +85,7 @@ def merge(merged_path):
                     return False  # No coffeescript compiler, skip this file
 
                 # Replace / with os separators and escape it
-                file_path_escaped = helper.shellquote(file_path.replace(os.path.sep, "/"))
+                file_path_escaped = helper.shellquote(file_path.replace("/", os.path.sep))
 
                 if "%s" in config.coffeescript_compiler:  # Replace %s with coffeescript file
                     command = config.coffeescript_compiler % file_path_escaped


### PR DESCRIPTION
I made a mistake in my [previous commit](https://github.com/HelloZeroNet/ZeroNet/pull/942/commits/a871b5dbe7fad2145a4421db906e81db28dd4d2a). I am very sorry.