### PR TITLE
Don't ask user for privatekey if file can be signed with auth_privatekey

### DIFF
--- a/plugins/Sidebar/media/Sidebar.coffee
+++ b/plugins/Sidebar/media/Sidebar.coffee
@@ -354,17 +354,18 @@ class Sidebar extends Class
 		@tag.find("#button-sign").off("click touchend").on "click touchend", =>
 			inner_path = @tag.find("#input-contents").val()
 
-			if wrapper.site_info.privatekey
-				# Privatekey stored in users.json
-				wrapper.ws.cmd "siteSign", {privatekey: "stored", inner_path: inner_path, update_changed_files: true}, (res) =>
-					wrapper.notifications.add "sign", "done", "#{inner_path} Signed!", 5000
+			wrapper.ws.cmd "fileRules", {inner_path: inner_path}, (res) =>
+				if wrapper.site_info.privatekey or wrapper.site_info.auth_address in res.signers
+					# Privatekey stored in users.json
+					wrapper.ws.cmd "siteSign", {privatekey: "stored", inner_path: inner_path, update_changed_files: true}, (res) =>
+						wrapper.notifications.add "sign", "done", "#{inner_path} Signed!", 5000
 
-			else
-				# Ask the user for privatekey
-				wrapper.displayPrompt "Enter your private key:", "password", "Sign", "", (privatekey) => # Prompt the private key
-					wrapper.ws.cmd "siteSign", {privatekey: privatekey, inner_path: inner_path, update_changed_files: true}, (res) =>
-						if res == "ok"
-							wrapper.notifications.add "sign", "done", "#{inner_path} Signed!", 5000
+				else
+					# Ask the user for privatekey
+					wrapper.displayPrompt "Enter your private key:", "password", "Sign", "", (privatekey) => # Prompt the private key
+						wrapper.ws.cmd "siteSign", {privatekey: privatekey, inner_path: inner_path, update_changed_files: true}, (res) =>
+							if res == "ok"
+								wrapper.notifications.add "sign", "done", "#{inner_path} Signed!", 5000
 
 			return false
 


### PR DESCRIPTION
In ZeroNet core, both `privatekey` and `auth_privatekey` are used to check if user can sign `content.json`, but there is no such check in `Sidebar` plugin.

Here we also check if `auth_address` can sign `content.json`.