### PR TITLE
Allow 'backup' or 'log' as directories

### DIFF
--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -859,7 +859,13 @@ class UiWebsocket(object):
 
     def actionServerShowdirectory(self, to, directory="backup"):
         import webbrowser
-        webbrowser.open('file://' + os.path.abspath(config.data_dir))
+
+        if directory == "backup":
+            directory = os.path.abspath(config.data_dir)
+        elif directory == "log":
+            directory = os.path.abspath(config.log_dir)
+
+        webbrowser.open('file://' + directory)
 
     def actionConfigSet(self, to, key, value):
         if key not in ["tor", "language"]:


### PR DESCRIPTION
Currently we have `directory="backup"` parameter for `actionServerShowdirectory`. This PR also allows `log` as valid directory.