### PR TITLE
Add commands for scripts

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -165,6 +165,11 @@ class Config(object):
         action.add_argument('message', help='Message to sign')
         action.add_argument('privatekey', help='Private key')
 
+        # Script actions
+        action = self.subparsers.add_parser("getDataDir", help='Retrieve ZeroNet data directory')
+        action = self.subparsers.add_parser("getLogDir", help='Retrieve ZeroNet log directory')
+        action = self.subparsers.add_parser("getRootDir", help='Retrieve ZeroNet installation place')
+
         # Config parameters
         self.parser.add_argument('--verbose', help='More detailed logging', action='store_true')
         self.parser.add_argument('--debug', help='Debug mode', action='store_true')

--- a/src/main.py
+++ b/src/main.py
@@ -481,6 +481,15 @@ class Actions(object):
         except Exception, err:
             print "Unknown response (%s): %s" % (err, res)
 
+    # Script actions
+    def getDataDir(self):
+        print config.data_dir
+
+    def getLogDir(self):
+        print config.log_dir
+
+    def getRootDir(self):
+        print os.path.dirname(os.path.abspath(__file__))
 
 actions = Actions()
 # Starts here when running zeronet.py

--- a/src/main.py
+++ b/src/main.py
@@ -483,10 +483,10 @@ class Actions(object):
 
     # Script actions
     def getDataDir(self):
-        print config.data_dir
+        print os.path.abspath(config.data_dir)
 
     def getLogDir(self):
-        print config.log_dir
+        print os.path.abspath(config.log_dir)
 
     def getRootDir(self):
         print os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Looks like `zeronet.py` is designed for *a)* those who don't use browser, *b)* scripts. This patch adds some more script commands (`getDataDir`, `getLogDir`, `getRootDir`) because paths can vary on different systems.