### PR TITLE
DbQuery and Newsfeed bug

### DIFF
--- a/plugins/Newsfeed/NewsfeedPlugin.py
+++ b/plugins/Newsfeed/NewsfeedPlugin.py
@@ -105,7 +105,7 @@ class UiWebsocketPlugin(object):
             for name, query in feeds.iteritems():
                 try:
                     db_query = DbQuery(query)
-                    db_query.wheres.append("%s LIKE ? OR %s LIKE ?" % (db_query.fields["body"], db_query.fields["title"]))
+                    db_query.wheres.append("(%s LIKE ? OR %s LIKE ?)" % (db_query.fields["body"], db_query.fields["title"]))
                     db_query.parts["ORDER BY"] = "date_added DESC"
                     db_query.parts["LIMIT"] = "30"
 

--- a/src/Db/DbQuery.py
+++ b/src/Db/DbQuery.py
@@ -22,6 +22,8 @@ class DbQuery:
     def parseWheres(self, query_where):
         if " AND " in query_where:
             return query_where.split(" AND ")
+        elif query_where:
+            return [query_where]
         else:
             return []
 


### PR DESCRIPTION
@shortcutme, I understand that SQL is difficult, but using regular expressions to parse SQL... Here are some more hacks:

1. Add (brackets) around NewsFeed's `body LIKE ? OR title LIKE ?`.
2. WHERE without AND is still WHERE