### PR TITLE
Fix logic BigfilePlugin.py

### DIFF
--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -387,7 +387,7 @@ class SiteStoragePlugin(object):
 
     def openBigfile(self, inner_path, prebuffer=0):
         file_info = self.site.content_manager.getFileInfo(inner_path)
-        if file_info and "piecemap" not in file_info:  # It's not a big file
+        if not file_info or (file_info and "piecemap" not in file_info):  # It's not a big file
             return False
 
         self.site.needFile(inner_path, blocking=False)  # Download piecemap


### PR DESCRIPTION
`self.site.content_manager.getFileInfo` returns `False` if the file info is not found in `self.contents`.

That means that the algorithm doesn't return in the line immediately after the modified line, which results in an error similar to the error bellow when it tries to access `file_info["sha512"]`

```
UiWSGIHandler error: TypeError: 'bool' object has no attribute '__getitem__' in UiServer.py line 40 > pywsgi.py line 494 > UiServer.py line 91 > UiRequest.py line 130 > MutePlugin.py line 138 > UiRequest.py line 272 > UiRequestPlugin.py line 22 > TranslateSitePlugin.py line 25 > FilePackPlugin.py line 66 > UiRequest.py line 473 > BigfilePlugin.py line 112 > BigfilePlugin.py line 396
```