### PR TITLE
Parse both UNION and UNION ALL

### DIFF
--- a/plugins/Newsfeed/NewsfeedPlugin.py
+++ b/plugins/Newsfeed/NewsfeedPlugin.py
@@ -53,7 +53,7 @@ class UiWebsocketPlugin(object):
                 s = time.time()
                 try:
                     query_raw, params = query_set
-                    query_parts = query_raw.split("UNION")
+                    query_parts = re.split(r"UNION(?:\s+ALL|)", query_raw)
                     for i, query_part in enumerate(query_parts):
                         db_query = DbQuery(query_part)
                         if day_limit:


### PR DESCRIPTION
For query like:
```sql
SELECT 1 AS field
UNION ALL
SELECT 2 AS field
```

Query is splitted to: 1. `SELECT 1 AS field` 2. `ALL SELECT 2 AS field`. So, second query is parsed as `{"ALL": "SELECT", "2 AS field": None}`. This PR fixed such behaviour.