### PR TITLE
Handle :param being an array

### DIFF
--- a/src/Db/DbCursor.py
+++ b/src/Db/DbCursor.py
@@ -47,6 +47,21 @@ class DbCursor:
                 keysvalues = "(%s) VALUES (%s)" % (keys, values)
                 query = re.sub("(.*)[?]", "\\1%s" % keysvalues, query)  # Replace the last ?
                 params = tuple(params.values())
+        elif isinstance(params, dict) and ":" in query:
+            new_params = dict()
+            values = []
+            for key, value in params.items():
+                if type(value) is list:
+                    for idx, val in enumerate(value):
+                        new_params[key + "__" + idx] = val
+
+                    new_names = [":" + key + "__" + idx for idx in range(len(value))]
+                    query = re.sub(r":" + re.escape(key) + "[)\s]", ", ".join(new_names))
+                else:
+                    new_params[key] = value
+
+            params = new_params
+
 
         s = time.time()
         # if query == "COMMIT": self.logging = True # Turn logging back on transaction commit

--- a/src/Db/DbCursor.py
+++ b/src/Db/DbCursor.py
@@ -56,7 +56,7 @@ class DbCursor:
                         new_params[key + "__" + str(idx)] = val
 
                     new_names = [":" + key + "__" + str(idx) for idx in range(len(value))]
-                    query = re.sub(r":" + re.escape(key) + "[)\s]", ", ".join(new_names))
+                    query = re.sub(r":" + re.escape(key) + r"([)\s])", ", ".join(new_names) + r"\1", query)
                 else:
                     new_params[key] = value
 

--- a/src/Db/DbCursor.py
+++ b/src/Db/DbCursor.py
@@ -53,9 +53,9 @@ class DbCursor:
             for key, value in params.items():
                 if type(value) is list:
                     for idx, val in enumerate(value):
-                        new_params[key + "__" + idx] = val
+                        new_params[key + "__" + str(idx)] = val
 
-                    new_names = [":" + key + "__" + idx for idx in range(len(value))]
+                    new_names = [":" + key + "__" + str(idx) for idx in range(len(value))]
                     query = re.sub(r":" + re.escape(key) + "[)\s]", ", ".join(new_names))
                 else:
                     new_params[key] = value


### PR DESCRIPTION
I am not sure if this is so important, but using `:params` in `NewsFeed` queries proved it is useful.

So now the following code will work:

```javascript
page.cmd("dbQuery", [
    "SELECT * FROM posts WHERE posts.reply_to IN :replies AND posts.reply_to_json IN :replies_json"
], {
    replies: ["1", "2"],
    replies_json: ["3", "4"]
});
```

Code from this PR transforms above SQL query to:
```sql
SELECT * FROM posts WHERE posts.reply_to IN :replies__0, :replies__1 AND posts.reply_to_json IN :replies_json__0, :replies_json__1
```
...and placeholders to:
```
{
    replies__0: "1",
    replies__1: "2",
    replies_json__0: "3",
    replies_json__1: "4"
}
```

---

I know you can use `?` right now, but that doesn't work with complex queries.