### PR TITLE
Use `exec init in globals(), locals()` instead of `exec(init, globals(), locals())`

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -642,7 +642,7 @@ class UiRequest(object):
             main = sys.modules["main"]
             s = time.time()
             if init:
-                exec(init, globals(), locals())
+                exec init in globals(), locals()
             for _ in range(times):
                 back = eval(code, globals(), locals())
             return ["%s run: %.3fs" % (times, time.time() - s), back]


### PR DESCRIPTION
We are using Python 2, not python 3, `exec(init, globals(), locals())` you are using in `bench()` sometimes raises SyntaxError's.

Closes #1252.