### PR TITLE
Gratipay shut down so removing

### DIFF
--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -175,7 +175,6 @@ Site:13DNDk..bhC2 Successfuly published to 3 peers
 
 - Bitcoin: 1QDhxQ6PraUZa21ET5fYUCPgdrwBomnFgX
 - Paypal: https://zeronet.readthedocs.org/en/latest/help_zeronet/donate/
-- Gratipay: https://gratipay.com/zeronet/
 
 ### 赞助商
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,6 @@ Site:13DNDk..bhC2 Successfuly published to 3 peers
 
 - Bitcoin: 1QDhxQ6PraUZa21ET5fYUCPgdrwBomnFgX
 - Paypal: https://zeronet.readthedocs.org/en/latest/help_zeronet/donate/
-- Gratipay: https://gratipay.com/zeronet/
 
 ### Sponsors
 


### PR DESCRIPTION
Gratipay shut down so people can't donate to the project through it
anymore.