### PR TITLE
FileQuery + CORS

### DIFF
--- a/plugins/Cors/CorsPlugin.py
+++ b/plugins/Cors/CorsPlugin.py
@@ -50,8 +50,8 @@ class UiWebsocketPlugin(object):
     def actionOptionalFileInfo(self, to, inner_path, *args, **kwargs):
         return self.corsFuncWrapper("actionOptionalFileInfo", to, inner_path, *args, **kwargs)
 
-    def actionFileQuery(self, to, inner_path, *args, **kwargs):
-        return self.corsFuncWrapper("actionFileQuery", to, inner_path, *args, **kwargs)
+    def actionFileQuery(self, to, dir_inner_path, *args, **kwargs):
+        return self.corsFuncWrapper("actionFileQuery", to, dir_inner_path, *args, **kwargs)
 
     def actionCorsPermission(self, to, address):
         site = self.server.sites.get(address)

--- a/plugins/Cors/CorsPlugin.py
+++ b/plugins/Cors/CorsPlugin.py
@@ -50,6 +50,9 @@ class UiWebsocketPlugin(object):
     def actionOptionalFileInfo(self, to, inner_path, *args, **kwargs):
         return self.corsFuncWrapper("actionOptionalFileInfo", to, inner_path, *args, **kwargs)
 
+    def actionFileQuery(self, to, inner_path, *args, **kwargs):
+        return self.corsFuncWrapper("actionFileQuery", to, inner_path, *args, **kwargs)
+
     def actionCorsPermission(self, to, address):
         site = self.server.sites.get(address)
         if site:

--- a/src/util/QueryJson.py
+++ b/src/util/QueryJson.py
@@ -30,7 +30,10 @@ def query(path_pattern, filter):
         filter_path, filter_val = filter.split("=")
         filter_path = filter_path.split(".")
         filter_key = filter_path.pop()  # Last element is the key
-        filter_val = int(filter_val)
+        try:
+            filter_val = int(filter_val)
+        except ValueError:
+            pass
     else:  # No filter
         filter_path = filter
         filter_path = filter_path.split(".")


### PR DESCRIPTION
Hello! I know `fileQuery` is quite an old thing, but it is useful to query some CORS sites that don't have any database.

So this PR adds two options:
1. First, it adds `fileQuery` to `corsFuncWrapper` list, so you can `fileQuery("cors-something...")` now.
2. The second change, which isn't connected with CORS, `fileQuery("file", "posts.slug=home")` is valid now - so you can use a string as value for searching.