### PR TITLE
'siteInfo' can be used as 'actionAs' argument for CORS sites

### DIFF
--- a/plugins/Cors/CorsPlugin.py
+++ b/plugins/Cors/CorsPlugin.py
@@ -27,7 +27,7 @@ class UiWebsocketPlugin(object):
         if super(UiWebsocketPlugin, self).hasSitePermission(address, cmd=cmd):
             return True
 
-        if not "Cors:%s" % address in self.site.settings["permissions"] or cmd not in ["dbQuery", "userGetSettings"]:
+        if not "Cors:%s" % address in self.site.settings["permissions"] or cmd not in ["dbQuery", "userGetSettings", "siteInfo"]:
             return False
         else:
             return True


### PR DESCRIPTION
Allows getting peer count/some content.json data/etc. from CORS site.