### PR TITLE
Fix mergerSiteAdd typo

### DIFF
--- a/plugins/disabled-Multiuser/MultiuserPlugin.py
+++ b/plugins/disabled-Multiuser/MultiuserPlugin.py
@@ -102,7 +102,7 @@ class UiWebsocketPlugin(object):
             "muteAdd", "muteRemove", "blacklistAdd", "blacklistRemove"
         )
         if config.multiuser_no_new_sites:
-            self.multiuser_denied_cmds += ("MergerSiteAdd", )
+            self.multiuser_denied_cmds += ("mergerSiteAdd", )
 
         super(UiWebsocketPlugin, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Security fix. Sites could be downloaded to proxies via running `mergerSiteAdd(site_address)` in console while on ZeroMe.