### PR TITLE
Support dumping sites larger than 2GB by allowing zip64

### DIFF
--- a/plugins/Sidebar/ZipStream.py
+++ b/plugins/Sidebar/ZipStream.py
@@ -7,7 +7,7 @@ class ZipStream(file):
     def __init__(self, dir_path):
         self.dir_path = dir_path
         self.pos = 0
-        self.zf = zipfile.ZipFile(self, 'w', zipfile.ZIP_DEFLATED)
+        self.zf = zipfile.ZipFile(self, 'w', zipfile.ZIP_DEFLATED, allowZip64 = True)
         self.buff = StringIO.StringIO()
         self.file_list = self.getFileList()
 


### PR DESCRIPTION
I needed this on Linux. Else >2GB files error out with an error seemingly appearing only on the CLI.