### PR TITLE
Fix 403 error when listening on 127.0.0.1:80.

### DIFF
--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -63,6 +63,14 @@ class UiServer:
             self.learn_allowed_host = False
         elif config.ui_ip == "127.0.0.1":
             self.allowed_hosts = set(["zero", "localhost:%s" % config.ui_port, "127.0.0.1:%s" % config.ui_port])
+            # "URI producers and normalizers should omit the port component and
+            # its ':' delimiter if port is empty or if its value would be the
+            # same as that of the scheme's default."
+            # Source: https://tools.ietf.org/html/rfc3986#section-3.2.3
+            # As a result, we need to support portless hosts if port 80 is in
+            # use.
+            if config.ui_port == 80:
+                self.allowed_hosts.update(["localhost", "127.0.0.1"])
             self.learn_allowed_host = False
         else:
             self.allowed_hosts = set([])


### PR DESCRIPTION
ZeroNet was incorrectly expecting a `:80` suffix in HTTP Host headers; most HTTP clients don't include that suffix.

To reproduce the issue, listen on 127.0.0.1:80 and try to connect to the UI in a web browser.  You'll get a 403 error without this patch; it works with this patch.

(Greetings from Namecoin!)