### PR TITLE
Support accessing ZeroNet via a transparent proxy.

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -204,6 +204,7 @@ class Config(object):
         self.parser.add_argument('--ui_port', help='Web interface bind port', default=43110, type=int, metavar='port')
         self.parser.add_argument('--ui_restrict', help='Restrict web access', default=False, metavar='ip', nargs='*')
         self.parser.add_argument('--ui_host', help='Allow access using this hosts', metavar='host', nargs='*')
+        self.parser.add_argument('--ui_trans_proxy', help='Allow access using a transparent proxy', action='store_true')
 
         self.parser.add_argument('--open_browser', help='Open homepage in web browser automatically',
                                  nargs='?', const="default_browser", metavar='browser_name')

--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -67,6 +67,7 @@ class UiServer:
         else:
             self.allowed_hosts = set([])
             self.learn_allowed_host = True  # It will pin to the first http request's host
+        self.allow_trans_proxy = config.ui_trans_proxy
 
         self.wrapper_nonces = []
         self.add_nonces = []


### PR DESCRIPTION
Transparent proxies redirect traffic to a different IP or port without modifying the traffic.  This PR allows ZeroNet to work with transparent proxies the same way that it currently works when used as an HTTP proxy.

One highly interesting use case for this is an experimental branch of ncdns that I'm working on, which automatically assigns a DNS `A` record of `127.0.0.1` to any `.bit` domain that is available via ZeroNet.  This enables both ZeroNet and clearnet `.bit` sites to be accessed via the same browser.

To test this patch, set your OS's `hosts` file to assign `127.0.0.1` to a ZeroNet-enabled `.bit` domain of your choice, make ZeroNet listen on `127.0.0.1:80` with the `--ui_trans_proxy` flag set, and visit that `.bit` domain in a web browser.

Greetings from Namecoin!