### PR TITLE
Only raise security error on ../

### DIFF
--- a/src/Site/SiteStorage.py
+++ b/src/Site/SiteStorage.py
@@ -358,7 +358,7 @@ class SiteStorage(object):
         if not inner_path:
             return self.directory
 
-        if ".." in inner_path:
+        if "../" in inner_path:
             raise Exception(u"File not allowed: %s" % inner_path)
 
         return u"%s/%s" % (self.directory, inner_path)

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -441,7 +441,7 @@ class UiRequest(object):
         if path.endswith("/"):
             path = path + "index.html"
 
-        if ".." in path or "./" in path:
+        if "../" in path or "./" in path:
             raise SecurityError("Invalid path")
 
         match = re.match("/media/(?P<address>[A-Za-z0-9]+[A-Za-z0-9\._-]+)(?P<inner_path>/.*|$)", path)


### PR DESCRIPTION
I've found that some files, such as http://127.0.0.1:43110/ZeroLSTN.bit/merged-ZeroLSTN2/1HLqL1eSZTRMpKLXjprjy7hFftuoAZEz1u/data/users/1GP11T6BYKsTz63srBNo43iTjZaX461o3i/artwork/Drunksouls_On_verra_plus_tard_....jpeg, raise a security error because ZeroNet thinks we're trying to escape from our sandboxed folder.

As far as I can tell, escape can only be had with `../` in a filepath, not just `..`, therefore I've changed this to be more specific in what it catches.

This allows these files to load successfully. As far as I can tell it does not open up any security vulnerabilities.