### PR TITLE
Support removing donation link / custom donation text

### DIFF
--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -409,16 +409,30 @@ class UiWebsocketPlugin(object):
             </li>
         """))
 
-        site_address = self.site.address
-        body.append(_(u"""
-            <li>
-             <label>{_[Site address]}</label><br>
-             <div class='flex'>
-              <span class='input text disabled'>{site_address}</span>
-              <a href='bitcoin:{site_address}' class='button' id='button-donate'>{_[Donate]}</a>
-             </div>
-            </li>
-        """))
+        donate_key = site.content_manager.contents.get("content.json", {}).get("donate", True)
+        if donate_key == False or donate_key == "":
+            pass
+        elif (type(donate_key) == str or type(donate_key) == unicode) and len(donate_key) > 0:
+            escaped_donate_key = cgi.escape(donate_key, True)
+            body.append(_(u"""
+                <li>
+                 <label>{_[Donate]}</label><br>
+                 <div class='flex'>
+                 {escaped_donate_key}
+                 </div>
+                </li>
+            """))
+        else:
+            site_address = self.site.address
+            body.append(_(u"""
+                <li>
+                 <label>{_[Site address]}</label><br>
+                 <div class='flex'>
+                  <span class='input text disabled'>{site_address}</span>
+                  <a href='bitcoin:{site_address}' class='button' id='button-donate'>{_[Donate]}</a>
+                 </div>
+                </li>
+            """))
 
     def sidebarRenderOwnedCheckbox(self, body, site):
         if self.site.settings["own"]:

--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -410,29 +410,33 @@ class UiWebsocketPlugin(object):
         """))
 
         donate_key = site.content_manager.contents.get("content.json", {}).get("donate", True)
+        site_address = self.site.address
+        body.append(_(u"""
+            <li>
+             <label>{_[Site address]}</label><br>
+             <div class='flex'>
+              <span class='input text disabled'>{site_address}</span>
+        """))
         if donate_key == False or donate_key == "":
             pass
         elif (type(donate_key) == str or type(donate_key) == unicode) and len(donate_key) > 0:
             escaped_donate_key = cgi.escape(donate_key, True)
             body.append(_(u"""
-                <li>
-                 <label>{_[Donate]}</label><br>
-                 <div class='flex'>
-                 {escaped_donate_key}
-                 </div>
-                </li>
+             </div>
+            </li>
+            <li>
+             <label>{_[Donate]}</label><br>
+             <div class='flex'>
+             {escaped_donate_key}
             """))
         else:
-            site_address = self.site.address
             body.append(_(u"""
-                <li>
-                 <label>{_[Site address]}</label><br>
-                 <div class='flex'>
-                  <span class='input text disabled'>{site_address}</span>
-                  <a href='bitcoin:{site_address}' class='button' id='button-donate'>{_[Donate]}</a>
-                 </div>
-                </li>
+              <a href='bitcoin:{site_address}' class='button' id='button-donate'>{_[Donate]}</a>
             """))
+        body.append(_(u"""
+             </div>
+            </li>
+        """))
 
     def sidebarRenderOwnedCheckbox(self, body, site):
         if self.site.settings["own"]:


### PR DESCRIPTION
Hi, as discussed in issue #1467, I'd like to be able to remove the "Donate" link in the sidebar for my site, and other users thought it might be nice to be able to provide a custom one.

This PR is the simplest implementation.  If a key `donate` is present in `content.json`, either as `"donate": false` or `"donate": ""`, the donation link is not rendered.  If a key `donate` is present in `content.json` and it's a string, it's escaped and rendered, allowing anyone to write out how they'd like to accept donations.  Otherwise, the existing "Donate" link is rendered as it is currently.

This PR does not try to interpret the contents of the string, nor does it provide a UI for editing the donation link string.  This provides just the basic rendering based on the presence or absence of a `donate` key.