### PR TITLE
Fix rev 3535 big javascript file

### DIFF
--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -114,8 +114,9 @@ class UiRequestPlugin(object):
             path_parts = kwargs["path_parts"]
             site = self.server.site_manager.get(path_parts["address"])
             big_file = site.storage.openBigfile(path_parts["inner_path"], prebuffer=2 * 1024 * 1024)
-            kwargs["file_obj"] = big_file
-            kwargs["file_size"] = big_file.size
+            if big_file:
+                kwargs["file_obj"] = big_file
+                kwargs["file_size"] = big_file.size
 
         return super(UiRequestPlugin, self).actionFile(file_path, *args, **kwargs)
 


### PR DESCRIPTION
Related to this issue : 
https://github.com/HelloZeroNet/ZeroNet/issues/1486

`openBigFile` will return false if it is not a big file but just javscript file. Added a condition to check that it is really a big file.