### PR TITLE
Fix issues with log messages related to Tor errors

### DIFF
--- a/src/Tor/TorManager.py
+++ b/src/Tor/TorManager.py
@@ -213,7 +213,7 @@ class TorManager(object):
         except Exception, err:
             self.conn = None
             self.setStatus(u"Error (%s)" % str(err).decode("utf8", "ignore"))
-            self.log.warning(u"Tor controller connect error: %s" % Debug.formatException(str(err).decode("utf8", "ignore")))
+            self.log.error(u"Tor controller connect error: %s" % Debug.formatException(str(err).decode("utf8", "ignore")))
             self.enabled = False
         return self.conn
 

--- a/src/Tor/TorManager.py
+++ b/src/Tor/TorManager.py
@@ -66,7 +66,10 @@ class TorManager(object):
                 raise Exception("No connection")
             self.log.debug("Tor proxy port %s check ok" % config.tor_proxy)
         except Exception, err:
-            self.log.info(u"Starting self-bundled Tor, due to Tor proxy port %s check error: %s" % (config.tor_proxy, err))
+            if sys.platform.startswith("win"):
+                self.log.info(u"Starting self-bundled Tor, due to Tor proxy port %s check error: %s" % (config.tor_proxy, err))
+            else:
+                self.log.info(u"Disabling Tor, because error while accessing Tor proxy at port %s: %s" % (config.tor_proxy, err))
             self.enabled = False
             # Change to self-bundled Tor ports
             from lib.PySocks import socks

--- a/src/main.py
+++ b/src/main.py
@@ -48,9 +48,6 @@ if not os.path.isfile("%s/sites.json" % config.data_dir):
 if not os.path.isfile("%s/users.json" % config.data_dir):
     open("%s/users.json" % config.data_dir, "w").write("{}")
 
-# Setup logging
-logging.WARNING = 15  # Don't display warnings if not in debug mode
-logging.addLevelName(15, "WARNING")
 if config.action == "main":
     from util import helper
     log_file_path = "%s/debug.log" % config.log_dir


### PR DESCRIPTION
This is a set of three commits. The first one (bottom) e6f0a86c5a is the most important, it fixes an issue where errors were not printed to the log at all! This wasted a lot of time trying to debug what is failing. The other two are smaller, more cosmetic fixes that I added while at it.

PS. To  be precise, without these patches it was difficult to debug when I hit this bug in Tor: https://trac.torproject.org/projects/tor/ticket/26913

```
commit 9bd10d5102d9bf1c778a74bf8d81e7ba4df336bb (HEAD -> PR--fix-log-warn, ghac/PR--fix-log-warn)
Author: redfish <redfish@galactica.pw>
Date:   Thu Aug 2 23:47:24 2018 +0000

    TorManager: correct the Tor error log message
    
    On Linux, there is no self-bundled Tor, so the message was not correct
    because it was stating that self-bundled Tor was being started.

commit 4c62840cefeb76eee4ef1a5ed3ad59c30820af14
Author: redfish <redfish@galactica.pw>
Date:   Thu Aug 2 23:42:50 2018 +0000

    TorManager: escalate log error for Tor auth
    
    This errorr is fatal for Tor usage (on Linux). Let's make escalate
    it. Also see the previous commit, without which, this error doesn't
    even get printed at all.

commit e6f0a86c5a9c32e084c16e0b32f603354afd3007
Author: redfish <redfish@galactica.pw>
Date:   Thu Aug 2 23:40:44 2018 +0000

    main: logging: do not override the warn level
    
    This fixes the very annoying problem where the log messages with
    level WARNING are not printed, while log messages with lower
    level INFO are printed. This is very confusing behavior and should
    be avoided. This was due to this override. If there is too much
    logging output in debug mode, then let's deescalate the level
    of the frequently-printed log messages down to DEBUG level.
```