### PR TITLE
Example of documentation folder inside the repository, with template for new entries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# ZeroNet documentation
+This should serve as a way to start documenting all features of ZeroNet when new code is added.
+
+## Structure
+We have some subfolders:
+* `howto`: Answers to simple and frequently asked questions or basic tutorials
+* `core`: Documentation about internals of core code
+* `plugins`: Documentation for plugins (usage and internals)
+* `features`: Documentation about features and enhancement to core
+
+## Writing new documentation
+Please copy the [template file](TEMPLATE.md) and edit it accordingly.

--- a/docs/TEMPLATE.md
+++ b/docs/TEMPLATE.md
@@ -1,0 +1,46 @@
+# Documentation for {Plugin / Feature name} - {Optional Brief description}
+{General description of the Plugin / Feature if needed}
+
+## Contacts and Issues
+```
+Maintainer: {First Maintainer Name / ZeroID account} - {Optional Maintainer Email / ZeroMail / Other contacts}
+Maintainer: {Second Maintainer Name / ZeroID account} - {Optional Maintainer Email / ZeroMail / Other contacts}
+Issue report to: {Place / Zite to signal bug to}
+Security issues: {Place / Zite to signal security issues to. Can be set omitted if no special security reports are needed}
+```
+
+## About current documentation
+```
+Last Updated: {Date of last update}
+Regarding version: {Feature / Plugin / ZeroNet version or commit hash}
+Documents: {"Names" of documented features}
+Undocumented: {Things that the current documentation doesn't explain}
+```
+
+## (Optional) Future plans about the {Plugin / Feature}
+{
+  - Things that are planned to do with links to the issues / Pull Requests
+  - Deprecation notices
+}
+
+## Known bugs
+{
+  List of known bugs that have great impact on the use of the feature
+}
+
+# Usage
+{
+  Things a user / site developer has to do to use such functionality
+  - Which keys in content.json does it use
+  - API calls it exposes
+  ...
+}
+
+# Usage examples
+{Some examples for common use cases}
+
+# Caveats
+{Tricky things that don't work as one may expect}
+
+# Internals
+{Documentation about how things are currently done, to help other developers to add functionality, edit and maintain the code}


### PR DESCRIPTION
Related to issue #1550 

A simple example of a documentation folder with an explanation of folder structure and a template for documenting new functionality.
@HelloZeroNet Please provide feedback