### PR TITLE
IPV6 Supports

### DIFF
--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -86,7 +86,7 @@ class SiteAnnouncerPlugin(object):
         # Sent request to tracker
         tracker_peer = connection_pool.get(tracker_address)  # Re-use tracker connection if possible
         if not tracker_peer:
-            tracker_ip, tracker_port = tracker_address.split(":")
+            tracker_ip, partion, tracker_port = tracker_address.rpartition(":")
             tracker_peer = Peer(tracker_ip, tracker_port, connection_server=self.site.connection_server)
             tracker_peer.is_tracker_connection = True
             connection_pool[tracker_address] = tracker_peer

--- a/plugins/AnnounceZero/AnnounceZeroPlugin.py
+++ b/plugins/AnnounceZero/AnnounceZeroPlugin.py
@@ -86,7 +86,7 @@ class SiteAnnouncerPlugin(object):
         # Sent request to tracker
         tracker_peer = connection_pool.get(tracker_address)  # Re-use tracker connection if possible
         if not tracker_peer:
-            tracker_ip, partion, tracker_port = tracker_address.rpartition(":")
+            tracker_ip, tracker_port = tracker_address.rsplit(":",1)
             tracker_peer = Peer(tracker_ip, tracker_port, connection_server=self.site.connection_server)
             tracker_peer.is_tracker_connection = True
             connection_pool[tracker_address] = tracker_peer

--- a/plugins/PeerDb/PeerDbPlugin.py
+++ b/plugins/PeerDb/PeerDbPlugin.py
@@ -60,7 +60,7 @@ class ContentDbPlugin(object):
     def iteratePeers(self, site):
         site_id = self.site_ids.get(site.address)
         for key, peer in site.peers.iteritems():
-            address, partition, port = key.rpartition(":")
+            address, port = key.rsplit(":",1)
             if peer.has_hashfield:
                 hashfield = sqlite3.Binary(peer.hashfield.tostring())
             else:

--- a/plugins/PeerDb/PeerDbPlugin.py
+++ b/plugins/PeerDb/PeerDbPlugin.py
@@ -60,7 +60,7 @@ class ContentDbPlugin(object):
     def iteratePeers(self, site):
         site_id = self.site_ids.get(site.address)
         for key, peer in site.peers.iteritems():
-            address, port = key.split(":")
+            address, partition, port = key.rpartition(":")
             if peer.has_hashfield:
                 hashfield = sqlite3.Binary(peer.hashfield.tostring())
             else:

--- a/src/Config.py
+++ b/src/Config.py
@@ -80,7 +80,8 @@ class Config(object):
             "udp://104.238.198.186:8000",  # US/LA
             "http://tracker.swateam.org.uk:2710/announce",  # US/NY
             "http://open.acgnxtracker.com:80/announce",  # DE
-            "http://retracker.mgts.by:80/announce"  # BY
+            "http://retracker.mgts.by:80/announce",  # BY
+            "http://ipv6.tracker.harry.lu:80/announce"  # IPV6
         ]
         # Platform specific
         if sys.platform.startswith("win"):

--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -81,9 +81,14 @@ class ConnectionServer(object):
         )
         try:
             self.pool = Pool(500)  # do not accept more than 500 connections
-            self.stream_server = StreamServer(
-                (self.ip, self.port), self.handleIncomingConnection, spawn=self.pool, backlog=100
-            )
+            if ":" in self.ip:
+                self.stream_server = StreamServer(
+                    (self.ip, self.port, 0, 0), self.handleIncomingConnection, spawn=self.pool, backlog=100
+                )
+            else:
+                self.stream_server = StreamServer(
+                    (self.ip, self.port), self.handleIncomingConnection, spawn=self.pool, backlog=100
+                )
         except Exception, err:
             self.log.info("StreamServer bind error: %s" % err)
 

--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -170,7 +170,7 @@ class ConnectionServer(object):
             if port == 0:
                 raise Exception("This peer is not connectable")
 
-            if (str(ip), int(port)) in self.peer_blacklist and not is_tracker_connection::
+            if (str(ip), int(port)) in self.peer_blacklist and not is_tracker_connection:
                 raise Exception("This peer is blacklisted")
 
             try:

--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -105,7 +105,10 @@ class ConnectionServer(object):
             self.stream_server.stop()
 
     def handleIncomingConnection(self, sock, addr):
-        ip, port = addr
+        if len(addr)==4:
+            ip, port, flowinfo, scopeid = addr
+        else:
+            ip, port = addr
         self.num_incoming += 1
 
         # Connection flood protection
@@ -167,7 +170,7 @@ class ConnectionServer(object):
             if port == 0:
                 raise Exception("This peer is not connectable")
 
-            if (ip, port) in self.peer_blacklist:
+            if (str(ip), int(port)) in self.peer_blacklist:
                 raise Exception("This peer is blacklisted")
 
             try:

--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -170,7 +170,7 @@ class ConnectionServer(object):
             if port == 0:
                 raise Exception("This peer is not connectable")
 
-            if (str(ip), int(port)) in self.peer_blacklist:
+            if (str(ip), int(port)) in self.peer_blacklist and not is_tracker_connection::
                 raise Exception("This peer is blacklisted")
 
             try:

--- a/src/File/FileRequest.py
+++ b/src/File/FileRequest.py
@@ -426,12 +426,20 @@ class FileRequest(object):
 
     # Check requested port of the other peer
     def actionCheckport(self, params):
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-            sock.settimeout(5)
-            if sock.connect_ex((self.connection.ip, params["port"])) == 0:
-                self.response({"status": "open", "ip_external": self.connection.ip})
-            else:
-                self.response({"status": "closed", "ip_external": self.connection.ip})
+        if ":" in self.connection.ip:
+            with closing(socket.socket(socket.AF_INET6, socket.SOCK_STREAM)) as sock:
+                sock.settimeout(5)
+                if sock.connect_ex((self.connection.ip, params["port"], 0, 0)) == 0:
+                    self.response({"status": "open", "ip_external": self.connection.ip})
+                else:
+                    self.response({"status": "closed", "ip_external": self.connection.ip})
+        else:
+            with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+                sock.settimeout(5)
+                if sock.connect_ex((self.connection.ip, params["port"])) == 0:
+                    self.response({"status": "open", "ip_external": self.connection.ip})
+                else:
+                    self.response({"status": "closed", "ip_external": self.connection.ip})
 
     # Unknown command
     def actionUnknown(self, cmd, params):

--- a/src/File/FileServer.py
+++ b/src/File/FileServer.py
@@ -40,11 +40,12 @@ class FileServer(ConnectionServer):
 
         hostname = socket.gethostname()
         addrs = socket.getaddrinfo(hostname,None)
-        for item in addrs:
+        for item in addrs: #IPV6 First (if you have ipv6, first use ipv6)
             if ":" in item[4][0] and "FE80::" not in item[4][0] and "fe80::" not in item[4][0]:
                 self.setIpExternal(item[4][0])
                 ip = item[4][0]
-                self.log.info("your ipv6 is {} " .format(item[4][0]))
+                self.log.info("Your IPV6 address: {} " .format(item[4][0]))
+                self.openport(port) # Make your ipv6 bootstrapper can be shared
                 break
 
         ConnectionServer.__init__(self, ip, port, self.handleRequest)

--- a/src/Site/Site.py
+++ b/src/Site/Site.py
@@ -766,7 +766,7 @@ class Site(object):
             else:
                 return False
         else:  # New peer
-            if (ip, port) in self.peer_blacklist:
+            if (str(ip), int(port)) in self.peer_blacklist:
                 return False  # Ignore blacklist (eg. myself)
             peer = Peer(ip, port, self)
             self.peers[key] = peer

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -245,7 +245,7 @@ class SiteAnnouncer(object):
         if config.trackers_proxy != "disable":
             raise AnnounceError("Udp trackers not available with proxies")
 
-        ip, partition, port = tracker_address.split("/")[0].rpartition(":")
+        ip, port = tracker_address.split("/")[0].rsplit(":",1)
         tracker = UdpTrackerClient(ip, int(port))
         if "ip4" in self.getOpenedServiceTypes():
             tracker.peer_port = self.fileserver_port

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -245,7 +245,7 @@ class SiteAnnouncer(object):
         if config.trackers_proxy != "disable":
             raise AnnounceError("Udp trackers not available with proxies")
 
-        ip, partition, port = tracker_address.split("/")[0].rpartition(":")
+        ip, partition, port = tracker_address.split("//")[1].rpartition(":")
         tracker = UdpTrackerClient(ip, int(port))
         if "ip4" in self.getOpenedServiceTypes():
             tracker.peer_port = self.fileserver_port

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -259,7 +259,7 @@ class SiteAnnouncer(object):
         if not back:
             raise AnnounceError("No response after %.0fs" % (time.time() - s))
         elif type(back) is dict and "response" in back:
-            if back["response"].has_key("peers"):
+            if "peers" in back["response"]:
                 peers = back["response"]["peers"]
             else:
                 peers = back["response"]["peers6"]
@@ -317,7 +317,7 @@ class SiteAnnouncer(object):
         # Decode peers
         try:
             response_dict = bencode.decode(response)
-            if response_dict.has_key("peers"):
+            if "peers" in response_dict:
                 peer_data = response_dict["peers"]
                 response = None
                 peer_count = len(peer_data) / 6
@@ -327,7 +327,7 @@ class SiteAnnouncer(object):
                     peer = peer_data[off:off + 6]
                     addr, port = struct.unpack('!LH', peer)
                     peers.append({"addr": socket.inet_ntoa(struct.pack('!L', addr)), "port": port})
-            else:  # Consider ipv6 tracker
+            if "peers6" in response_dict:  # Consider IPV6 Tracker
                 peer_data = response_dict["peers6"]
                 response = None
                 peer_count = len(peer_data) / 18
@@ -335,7 +335,7 @@ class SiteAnnouncer(object):
                 for peer_offset in xrange(peer_count):
                     off = 18 * peer_offset
                     peer = peer_data[off:off + 18]
-                    addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8, port = struct.unpack('!HHHHHHHHH', peer)
+                    addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8, port = struct.unpack('HHHHHHHHH', peer)
                     ipv6addr = hex(addr1)[2:] + ":" + hex(addr2)[2:] + ":" + hex(addr3)[2:] + ":" + hex(addr4)[2:] + ":" + hex(addr5)[2:] + ":" + hex(addr6)[2:] + ":" +hex(addr7)[2:] + ":" + hex(addr8)[2:]
                     peers.append({"addr": ipv6addr, "port": port})
         except Exception as err:

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -259,7 +259,10 @@ class SiteAnnouncer(object):
         if not back:
             raise AnnounceError("No response after %.0fs" % (time.time() - s))
         elif type(back) is dict and "response" in back:
-            peers = back["response"]["peers"]
+            if back["response"].has_key("peers"):
+                peers = back["response"]["peers"]
+            else:
+                peers = back["response"]["peers6"]
         else:
             raise AnnounceError("Invalid response: %r" % back)
 

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -313,15 +313,30 @@ class SiteAnnouncer(object):
 
         # Decode peers
         try:
-            peer_data = bencode.decode(response)["peers"]
-            response = None
-            peer_count = len(peer_data) / 6
-            peers = []
-            for peer_offset in xrange(peer_count):
-                off = 6 * peer_offset
-                peer = peer_data[off:off + 6]
-                addr, port = struct.unpack('!LH', peer)
-                peers.append({"addr": socket.inet_ntoa(struct.pack('!L', addr)), "port": port})
+            response_dict = bencode.decode(response)
+            if response_dict.has_key("peers"):
+                peer_data = response_dict["peers"]
+                response = None
+                peer_count = len(peer_data) / 6
+                peers = []
+                for peer_offset in xrange(peer_count):
+                    off = 6 * peer_offset
+                    peer = peer_data[off:off + 6]
+                    addr, port = struct.unpack('!LH', peer)
+                    peers.append({"addr": socket.inet_ntoa(struct.pack('!L', addr)), "port": port})
+            else:  # Consider ipv6 tracker
+                peer_data = response_dict["peers6"]
+                response = None
+                peer_count = len(peer_data) / 18
+                peers = []
+                for peer_offset in xrange(peer_count):
+                    off = 18 * peer_offset
+                    peer = peer_data[off:off + 18]
+                    addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8, port = struct.unpack('!HHHHHHHHH', peer)
+                    ipv6addr = hex(addr1)[2:len(hex(addr1))] + ":" + hex(addr2)[2:len(hex(addr2))] + ":" + hex(addr3)[2:len(hex(addr3))] + ":" + hex(addr4)[2:len(hex(addr4))] + ":" + hex(addr5)[2:len(hex(addr5))] + ":" + hex(addr6)[2:len(hex(addr6))] + ":" +hex(addr7)[2:len(hex(addr7))] + ":" + hex(addr8)[2:len(hex(addr8))]
+                    self.site.log.debug("IPV6 Tracker, port: %s" % port)
+                    self.site.log.debug("IPV6 Tracker, ipv6addr: %s" % ipv6addr)
+                    peers.append({"addr": ipv6addr, "port": port})
         except Exception as err:
             raise AnnounceError("Invalid response: %r (%s)" % (response, err))
 

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -245,7 +245,7 @@ class SiteAnnouncer(object):
         if config.trackers_proxy != "disable":
             raise AnnounceError("Udp trackers not available with proxies")
 
-        ip, partition, port = tracker_address.split("//")[1].rpartition(":")
+        ip, partition, port = tracker_address.split("/")[0].rpartition(":")
         tracker = UdpTrackerClient(ip, int(port))
         if "ip4" in self.getOpenedServiceTypes():
             tracker.peer_port = self.fileserver_port
@@ -337,8 +337,6 @@ class SiteAnnouncer(object):
                     peer = peer_data[off:off + 18]
                     addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8, port = struct.unpack('!HHHHHHHHH', peer)
                     ipv6addr = hex(addr1)[2:len(hex(addr1))] + ":" + hex(addr2)[2:len(hex(addr2))] + ":" + hex(addr3)[2:len(hex(addr3))] + ":" + hex(addr4)[2:len(hex(addr4))] + ":" + hex(addr5)[2:len(hex(addr5))] + ":" + hex(addr6)[2:len(hex(addr6))] + ":" +hex(addr7)[2:len(hex(addr7))] + ":" + hex(addr8)[2:len(hex(addr8))]
-                    self.site.log.debug("IPV6 Tracker, port: %s" % port)
-                    self.site.log.debug("IPV6 Tracker, ipv6addr: %s" % ipv6addr)
                     peers.append({"addr": ipv6addr, "port": port})
         except Exception as err:
             raise AnnounceError("Invalid response: %r (%s)" % (response, err))

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -336,7 +336,7 @@ class SiteAnnouncer(object):
                     off = 18 * peer_offset
                     peer = peer_data[off:off + 18]
                     addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8, port = struct.unpack('!HHHHHHHHH', peer)
-                    ipv6addr = hex(addr1)[2:len(hex(addr1))] + ":" + hex(addr2)[2:len(hex(addr2))] + ":" + hex(addr3)[2:len(hex(addr3))] + ":" + hex(addr4)[2:len(hex(addr4))] + ":" + hex(addr5)[2:len(hex(addr5))] + ":" + hex(addr6)[2:len(hex(addr6))] + ":" +hex(addr7)[2:len(hex(addr7))] + ":" + hex(addr8)[2:len(hex(addr8))]
+                    ipv6addr = hex(addr1)[2:] + ":" + hex(addr2)[2:] + ":" + hex(addr3)[2:] + ":" + hex(addr4)[2:] + ":" + hex(addr5)[2:] + ":" + hex(addr6)[2:] + ":" +hex(addr7)[2:] + ":" + hex(addr8)[2:]
                     peers.append({"addr": ipv6addr, "port": port})
         except Exception as err:
             raise AnnounceError("Invalid response: %r (%s)" % (response, err))

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -245,7 +245,7 @@ class SiteAnnouncer(object):
         if config.trackers_proxy != "disable":
             raise AnnounceError("Udp trackers not available with proxies")
 
-        ip, port = tracker_address.split("/")[0].split(":")
+        ip, partition, port = tracker_address.split("/")[0].rpartition(":")
         tracker = UdpTrackerClient(ip, int(port))
         if "ip4" in self.getOpenedServiceTypes():
             tracker.peer_port = self.fileserver_port

--- a/src/Tor/TorManager.py
+++ b/src/Tor/TorManager.py
@@ -52,7 +52,7 @@ class TorManager(object):
         else:
             self.fileserver_port = config.fileserver_port
 
-        self.ip, self.port = config.tor_controller.split(":")
+        self.ip, partition, self.port = config.tor_controller.rpartition(":")
         self.port = int(self.port)
 
         self.proxy_ip, self.proxy_port = config.tor_proxy.split(":")
@@ -182,12 +182,18 @@ class TorManager(object):
         if "socket_noproxy" in dir(socket):  # Socket proxy-patched, use non-proxy one
             conn = socket.socket_noproxy(socket.AF_INET, socket.SOCK_STREAM)
         else:
-            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            if ":" in self.ip:
+                conn = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            else:
+                conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         self.log.info("Connecting to Tor Controller %s:%s" % (self.ip, self.port))
         try:
             with self.lock:
-                conn.connect((self.ip, self.port))
+                if ":" in self.ip:
+                    conn.connect((self.ip, self.port, 0, 0))
+                else:
+                    conn.connect((self.ip, self.port))
 
                 # Auth cookie file
                 res_protocol = self.send("PROTOCOLINFO", conn)
@@ -335,7 +341,10 @@ class TorManager(object):
             self.log.debug("Waiting for startup...")
             self.event_started.get()
         if config.tor == "always":  # Every socket is proxied by default, in this mode
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            if ":" in self.ip:
+                sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+            else:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         else:
             sock = socks.socksocket()
             sock.set_proxy(socks.SOCKS5, self.proxy_ip, self.proxy_port)

--- a/src/Tor/TorManager.py
+++ b/src/Tor/TorManager.py
@@ -52,7 +52,7 @@ class TorManager(object):
         else:
             self.fileserver_port = config.fileserver_port
 
-        self.ip, partition, self.port = config.tor_controller.rpartition(":")
+        self.ip, self.port = config.tor_controller.rsplit(":",1)
         self.port = int(self.port)
 
         self.proxy_ip, self.proxy_port = config.tor_proxy.split(":")

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -348,7 +348,7 @@ class UiRequest(object):
             for peer in match.group(1).split(","):
                 if not re.match(".*?:[0-9]+$", peer):
                     continue
-                ip, port = peer.split(":")
+                ip, partition, port = peer.rpartition(":")
                 if site.addPeer(ip, int(port), source="query_string"):
                     num_added += 1
             site.log.debug("%s peers added by query string" % num_added)

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -348,7 +348,7 @@ class UiRequest(object):
             for peer in match.group(1).split(","):
                 if not re.match(".*?:[0-9]+$", peer):
                     continue
-                ip, partition, port = peer.rpartition(":")
+                ip, port = peer.rsplit(":",1)
                 if site.addPeer(ip, int(port), source="query_string"):
                     num_added += 1
             site.log.debug("%s peers added by query string" % num_added)

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -91,7 +91,8 @@ def packPeers(peers):
 def packAddress(ip, port):
     if ":" in ip:
         addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
-        return struct.pack("HHHHHHHH",str(int(addr1,16)),str(int(addr2,16)),int(addr3,16)),str(int(addr4,16)),int(addr5,16)),str(int(addr6,16)),int(addr7,16)),str(int(addr8,16))) + struct.pack("H", port)
+        logging.info("IPV6addr8: %s" % addr8)
+        return struct.pack("HHHHHHHH",str(int(addr1,16)),str(int(addr2,16)),str(int(addr3,16)),str(int(addr4,16)),str(int(addr5,16)),str(int(addr6,16)),str(int(addr7,16)),str(int(addr8,16))) + struct.pack("H", port)
     else:
         return socket.inet_aton(ip) + struct.pack("H", port)
 

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -91,7 +91,7 @@ def packPeers(peers):
 def packAddress(ip, port):
     if ":" in ip:
         addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
-        return struct.pack("HHHHHHHH",str(int(addr1,16)),str(int(addr2,16)),str(int(addr3,16)),str(int(addr4,16)),str(int(addr5,16)),str(int(addr6,16)),str(int(addr7,16)),str(int(addr8,16))) + struct.pack("H", port)
+        return struct.pack("HHHHHHHH",int(addr1,16),int(addr2,16),int(addr3,16),int(addr4,16),int(addr5,16),int(addr6,16),int(addr7,16),int(addr8,16)) + struct.pack("H", port)
     else:
         return socket.inet_aton(ip) + struct.pack("H", port)
 

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -96,8 +96,14 @@ def packAddress(ip, port):
             num_b = b_ip.count(":")
             num_zerobyte = 14 - num_f - num_b
             addr = range(num_f + num_b + 2)
-            addr[0:num_f+1] = f_ip.split(":")
-            addr[num_f+1:num_f+num_b+2] = b_ip.split(":")
+            if num_f > 0:
+                addr[0:num_f+1] = f_ip.split(":",num_f)
+            else:
+                addr[0]= f_ip
+            if num_b > 0:
+                addr[num_f+1:num_f+num_b+2] = b_ip.split(":",num_b)
+            else:
+                addr[num_f+1] = b_ip
             return_pack = ""
             for addr_f in addr[0:num_f+1]:
                 return_pack = return_pack + struct.pack("H",int(addr_f,16))
@@ -107,7 +113,7 @@ def packAddress(ip, port):
                 return_pack = return_pack + struct.pack("H",int(addr_b,16))
             return_pack = return_pack + struct.pack("H", port)
             return return_pack
-        else:                
+        else:
             addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
             return struct.pack("HHHHHHHH",int(addr1,16),int(addr2,16),int(addr3,16),int(addr4,16),int(addr5,16),int(addr6,16),int(addr7,16),int(addr8,16)) + struct.pack("H", port)
     else:

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -99,7 +99,7 @@ def packAddress(ip, port):
 # From 6byte or 18byte format to ip, port
 def unpackAddress(packed):
     if len(packed) == 18:
-        addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8,port = struct.upack("HHHHHHHHH",packed)
+        addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8,port = struct.unpack("HHHHHHHHH",packed)
         ip = hex(addr1).replace("0x","") + ":" + hex(addr2).replace("0x","") + ":" + hex(addr3).replace("0x","") + ":" + hex(addr4).replace("0x","") + ":" + hex(addr5).replace("0x","") + ":" + hex(addr6).replace("0x","") + ":" + hex(addr7).replace("0x","") + ":" + hex(addr8).replace("0x","")
         return ip, port
     else:

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -94,7 +94,7 @@ def packAddress(ip, port):
             f_ip, b_ip = ip.split("::")
             num_f = f_ip.count(":")
             num_b = b_ip.count(":")
-            num_zerobyte = 14 - num_f - num_b
+            num_zerobyte = 6 - num_f - num_b
             addr = range(num_f + num_b + 2)
             if num_f > 0:
                 addr[0:num_f+1] = f_ip.split(":",num_f)

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -124,7 +124,7 @@ def packAddress(ip, port):
 def unpackAddress(packed):
     if len(packed) == 18:
         addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8,port = struct.unpack("HHHHHHHHH",packed)
-        ip = hex(addr1).replace("0x","") + ":" + hex(addr2).replace("0x","") + ":" + hex(addr3).replace("0x","") + ":" + hex(addr4).replace("0x","") + ":" + hex(addr5).replace("0x","") + ":" + hex(addr6).replace("0x","") + ":" + hex(addr7).replace("0x","") + ":" + hex(addr8).replace("0x","")
+        ip = hex(addr1)[2:] + ":" + hex(addr2)[2:] + ":" + hex(addr3)[2:] + ":" + hex(addr4)[2:] + ":" + hex(addr5)[2:] + ":" + hex(addr6)[2:] + ":" + hex(addr7)[2:] + ":" + hex(addr8)[2:]
         return ip, port
     else:
         assert len(packed) == 6, "Invalid length ip4 packed address: %s" % len(packed)

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -87,7 +87,7 @@ def packPeers(peers):
     return packed_peers
 
 
-# ip, port to packed 6byte format
+# ip, port to packed 6byte or 18byte format
 def packAddress(ip, port):
     if ":" in ip:
         addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
@@ -97,7 +97,7 @@ def packAddress(ip, port):
         return socket.inet_aton(ip) + struct.pack("H", port)
 
 
-# From 6byte format to ip, port
+# From 6byte or 18byte format to ip, port
 def unpackAddress(packed):
     if len(packed) == 18:
         addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8,port = struct.upack("HHHHHHHHH",packed)

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -91,7 +91,6 @@ def packPeers(peers):
 def packAddress(ip, port):
     if ":" in ip:
         addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
-        logging.info("IPV6addr8: %s" % addr8)
         return struct.pack("HHHHHHHH",str(int(addr1,16)),str(int(addr2,16)),str(int(addr3,16)),str(int(addr4,16)),str(int(addr5,16)),str(int(addr6,16)),str(int(addr7,16)),str(int(addr8,16))) + struct.pack("H", port)
     else:
         return socket.inet_aton(ip) + struct.pack("H", port)

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -90,8 +90,26 @@ def packPeers(peers):
 # ip, port to packed 6byte or 18byte format
 def packAddress(ip, port):
     if ":" in ip:
-        addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
-        return struct.pack("HHHHHHHH",int(addr1,16),int(addr2,16),int(addr3,16),int(addr4,16),int(addr5,16),int(addr6,16),int(addr7,16),int(addr8,16)) + struct.pack("H", port)
+        if "::" in ip:
+            f_ip, b_ip = ip.split("::")
+            num_f = f_ip.count(":")
+            num_b = b_ip.count(":")
+            num_zerobyte = 14 - num_f - num_b
+            addr = range(num_f + num_b + 2)
+            addr[0:num_f+1] = f_ip.split(":")
+            addr[num_f+1:num_f+num_b+2] = b_ip.split(":")
+            return_pack = ""
+            for addr_f in addr[0:num_f+1]:
+                return_pack = return_pack + struct.pack("H",int(addr_f,16))
+            for addr_zerobyte in range(num_zerobyte):
+                return_pack = return_pack + struct.pack("H",0)
+            for addr_b in addr[num_f+1 : num_f+num_b+2]:
+                return_pack = return_pack + struct.pack("H",int(addr_b,16))
+            return_pack = return_pack + struct.pack("H", port)
+            return return_pack
+        else:                
+            addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
+            return struct.pack("HHHHHHHH",int(addr1,16),int(addr2,16),int(addr3,16),int(addr4,16),int(addr5,16),int(addr6,16),int(addr7,16),int(addr8,16)) + struct.pack("H", port)
     else:
         return socket.inet_aton(ip) + struct.pack("H", port)
 

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -89,13 +89,22 @@ def packPeers(peers):
 
 # ip, port to packed 6byte format
 def packAddress(ip, port):
-    return socket.inet_aton(ip) + struct.pack("H", port)
+    if ":" in ip:
+        addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8 = ip.split(":",7)
+        return struct.pack("HHHHHHHH",str(int(addr1,16)),str(int(addr2,16)),int(addr3,16)),str(int(addr4,16)),int(addr5,16)),str(int(addr6,16)),int(addr7,16)),str(int(addr8,16))) + struct.pack("H", port)
+    else:
+        return socket.inet_aton(ip) + struct.pack("H", port)
 
 
 # From 6byte format to ip, port
 def unpackAddress(packed):
-    assert len(packed) == 6, "Invalid length ip4 packed address: %s" % len(packed)
-    return socket.inet_ntoa(packed[0:4]), struct.unpack_from("H", packed, 4)[0]
+    if len(packed) == 18:
+        addr1,addr2,addr3,addr4,addr5,addr6,addr7,addr8,port = struct.upack("HHHHHHHHH",packed)
+        ip = hex(addr1).replace("0x","") + ":" + hex(addr2).replace("0x","") + ":" + hex(addr3).replace("0x","") + ":" + hex(addr4).replace("0x","") + ":" + hex(addr5).replace("0x","") + ":" + hex(addr6).replace("0x","") + ":" + hex(addr7).replace("0x","") + ":" + hex(addr8).replace("0x","")
+        return ip, port
+    else:
+        assert len(packed) == 6, "Invalid length ip4 packed address: %s" % len(packed)
+        return socket.inet_ntoa(packed[0:4]), struct.unpack_from("H", packed, 4)[0]
 
 
 # onion, port to packed 12byte format


### PR DESCRIPTION
IPV6 Supports: 
(If you donot have ipv6, these change would not change the logic of your code. If you have public ipv6, these change would let you choose ipv6 as your connection server first (can let the users to choose if needed ), not your public ipv4 address, in which you can also connect these ipv4 peers and ipv4 trackers. )

- [x] UDP/TCP Trackers Supports

- [x] Peer Exchange Supports

- [x] BigFile Supports

- [x] Bootstrapper Supports

- [x] Testing