### PR TITLE
Bug Fixs

### DIFF
--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -162,7 +162,7 @@ class ConnectionServer(object):
             if port == 0:
                 raise Exception("This peer is not connectable")
 
-            if (ip, port) in self.peer_blacklist:
+            if (str(ip), int(port)) in self.peer_blacklist:
                 raise Exception("This peer is blacklisted")
 
             try:

--- a/src/Site/Site.py
+++ b/src/Site/Site.py
@@ -766,7 +766,7 @@ class Site(object):
             else:
                 return False
         else:  # New peer
-            if (ip, port) in self.peer_blacklist:
+            if (str(ip), int(port)) in self.peer_blacklist:
                 return False  # Ignore blacklist (eg. myself)
             peer = Peer(ip, port, self)
             self.peers[key] = peer


### PR DESCRIPTION
They do not match. Beacuse ip and port in (ip, port) are unicode type while ip in peer_blacklist is string type and port in  in peer_blacklist is int type.