### PR TITLE
Fix bootstrapper is blocked by itself

### DIFF
--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -162,7 +162,7 @@ class ConnectionServer(object):
             if port == 0:
                 raise Exception("This peer is not connectable")
 
-            if (ip, port) in self.peer_blacklist:
+            if (ip, port) in self.peer_blacklist and not is_tracker_connection:
                 raise Exception("This peer is blacklisted")
 
             try:


### PR DESCRIPTION
Make the bootstrapper server can add its own ip and port in its own bootstrapper.db as a peer.