### PR TITLE
Allow using other domain resolver plugins along with Zeroname

### DIFF
--- a/plugins/Zeroname/SiteManagerPlugin.py
+++ b/plugins/Zeroname/SiteManagerPlugin.py
@@ -21,15 +21,16 @@ class SiteManagerPlugin(object):
         if not self.get(config.bit_resolver):
             self.need(config.bit_resolver)  # Need ZeroName site
 
-    # Checks if its a valid address
+    # Checks if it's a valid address
     def isAddress(self, address):
-        if self.isDomain(address):
-            return True
-        else:
-            return super(SiteManagerPlugin, self).isAddress(address)
+        return self.isBitDomain(address) or super(SiteManagerPlugin, self).isAddress(address)
 
     # Return: True if the address is domain
     def isDomain(self, address):
+        return self.isBitDomain(address) or super(SiteManagerPlugin, self).isDomain(address)
+
+    # Return: True if the address is .bit domain
+    def isBitDomain(self, address):
         return re.match("(.*?)([A-Za-z0-9_-]+\.bit)$", address)
 
     # Resolve domain
@@ -54,7 +55,7 @@ class SiteManagerPlugin(object):
     # Return or create site and start download site files
     # Return: Site or None if dns resolve failed
     def need(self, address, *args, **kwargs):
-        if self.isDomain(address):  # Its looks like a domain
+        if self.isBitDomain(address):  # Its looks like a domain
             address_resolved = self.resolveDomain(address)
             if address_resolved:
                 address = address_resolved
@@ -67,7 +68,7 @@ class SiteManagerPlugin(object):
     def get(self, address):
         if not self.loaded:  # Not loaded yet
             self.load()
-        if self.isDomain(address):  # Its looks like a domain
+        if self.isBitDomain(address):  # Its looks like a domain
             address_resolved = self.resolveDomain(address)
             if address_resolved:  # Domain found
                 site = self.sites.get(address_resolved)
@@ -79,5 +80,5 @@ class SiteManagerPlugin(object):
                 site = self.sites.get(address)
 
         else:  # Access by site address
-            site = self.sites.get(address)
+            site = super(SiteManagerPlugin, self).get(address)
         return site


### PR DESCRIPTION
Fixes several closely related bugs in Zeroname Plugin, those prevent correct work of other domain resolvers:

1. get(), isDomain(): when an address doesn't look like a valid domain, pass control to the next plugin in a chain.

3. Move the .bit-domain matching logic to a separate method isBitDomain().

2. get(), need(): use isBitDomain(), not isDomain() to check if domain resolving is needed in order to not interfere with other domain resolvers.

4. Also rewrite isAddress() to make it look similar to the new implementation of isDomain().