### PR TITLE
Make it compatible with pyinstaller for browser build

### DIFF
--- a/src/Plugin/PluginManager.py
+++ b/src/Plugin/PluginManager.py
@@ -19,7 +19,7 @@ class PluginManager:
         self.plugin_names = []  # Loaded plugin names
         self.after_load = []  # Execute functions after loaded plugins
 
-        sys.path.append(self.plugin_path)
+        sys.path.append(os.path.join(os.getcwd(), self.plugin_path))
         self.migratePlugins()
 
         if config.debug:  # Auto reload Plugins on file change


### PR DESCRIPTION
We need absolute path for plugin so that pyinstaller can work. It is needed for the browser using PyQt5 to work (https://github.com/rllola/ZeronetBrowser). It should not affect how Zeronet works in general.