### PR TITLE
Import Debug in Db/Db.py

### DIFF
--- a/src/Db/Db.py
+++ b/src/Db/Db.py
@@ -6,6 +6,7 @@ import re
 import os
 import gevent
 
+from Debug import Debug
 from DbCursor import DbCursor
 from Config import config
 from util import SafeRe


### PR DESCRIPTION
Previously, when I made a mistake in my dbschema.json file, rebuilding resulted in this error:
> Internal error: NameError: global name 'Debug' is not defined
UiWebsocket.py line 81 > UiWebsocket.py line 267 > SidebarPlugin.py line 750 > SiteStorage.py line 82 > Db.py line 219

This is the proposed fix by @imachug 