### PR TITLE
Convert websocket message to string if not already

### DIFF
--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -78,6 +78,8 @@ class UiWebsocket(object):
 
             if message:
                 try:
+                    if type(message) is not str:
+                        message = str(message)
                     req = json.loads(message)
                     self.handleRequest(req)
                 except Exception, err:


### PR DESCRIPTION
So while experimenting with sending custom websocket messages to ZeroNet, I found that some websocket libraries (mainly the one Godot [ships with](https://docs.godotengine.org/en/latest/classes/class_websocketclient.html)) only supports sending websocket packets are bytearray's, rather than as a string.

So, a quick patch to convert websocket messages to strings (wrapped in the existing try/except statement) and I was able to successfully make a connection and perform commands!

![image](https://user-images.githubusercontent.com/1342360/48874282-c2bf8500-edf2-11e8-93ce-f0d7e0370a18.png)
