### PR TITLE
Allow IP addresses via WebSocket API

### DIFF
--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -62,7 +62,9 @@ class UiServer:
             self.allowed_hosts = set(config.ui_host)
             self.learn_allowed_host = False
         elif config.ui_ip == "127.0.0.1":
-            self.allowed_hosts = set(["zero", "localhost:%s" % config.ui_port, "127.0.0.1:%s" % config.ui_port])
+            # IP Addresses are inherently allowed as they are immune to DNS
+            # rebinding attacks.
+            self.allowed_hosts = set(["zero", "localhost:%s" % config.ui_port])
             # "URI producers and normalizers should omit the port component and
             # its ':' delimiter if port is empty or if its value would be the
             # same as that of the scheme's default."
@@ -70,7 +72,7 @@ class UiServer:
             # As a result, we need to support portless hosts if port 80 is in
             # use.
             if config.ui_port == 80:
-                self.allowed_hosts.update(["localhost", "127.0.0.1"])
+                self.allowed_hosts.update(["localhost"])
             self.learn_allowed_host = False
         else:
             self.allowed_hosts = set([])


### PR DESCRIPTION
Fixes #1799 

Allows a websocket connection originating from any IP address to connect. `allowed_hosts` is still in place for anything other than an IP address. This is implemented under the assumption that IP addresses are not subject to DNS rebinding attacks.

IP addresses have also been removed from the list of default allowed_hosts as they are inherently allowed by this new rule.