### PR TITLE
Make code compatible with Python 2.7 and Python >=3.6 (Syntax: fix exceptions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
  - pip list
 before_script:
   - openssl version -a
+  - bash tools/python3_check.sh
 script:
  - python -m pytest -x plugins/CryptMessage/Test
  - python -m pytest -x plugins/Bigfile/Test

--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -178,7 +178,7 @@ class UiWebsocketPlugin(object):
                     self.site.content_manager.loadContent(file_info["content_inner_path"], add_bad_files=False, force=True)
                     try:
                         self.site.storage.delete(piecemap_inner_path)
-                    except Exception, err:
+                    except Exception as err:
                         self.log.error("File %s delete error: %s" % (piecemap_inner_path, err))
 
         return super(UiWebsocketPlugin, self).actionFileDelete(to, inner_path)

--- a/plugins/Chart/ChartPlugin.py
+++ b/plugins/Chart/ChartPlugin.py
@@ -39,7 +39,7 @@ class UiWebsocketPlugin(object):
             if not query.strip().upper().startswith("SELECT"):
                 raise Exception("Only SELECT query supported")
             res = db.execute(query, params)
-        except Exception, err:  # Response the error to client
+        except Exception as err:  # Response the error to client
             self.log.error("ChartDbQuery error: %s" % err)
             return {"error": str(err)}
         # Convert result to dict

--- a/plugins/CryptMessage/CryptMessagePlugin.py
+++ b/plugins/CryptMessage/CryptMessagePlugin.py
@@ -105,7 +105,7 @@ class UiWebsocketPlugin(object):
                     decrypted = ctx.ciphering(encrypted_text)
                     if decrypted and decrypted.decode("utf8"):  # Valid text decoded
                         text = decrypted
-                except Exception, err:
+                except Exception as err:
                     pass
             texts.append(text)
 

--- a/plugins/MergerSite/MergerSitePlugin.py
+++ b/plugins/MergerSite/MergerSitePlugin.py
@@ -343,7 +343,7 @@ class SiteManagerPlugin(object):
             # Update merged sites
             try:
                 merged_type = site.content_manager.contents.get("content.json", {}).get("merged_type")
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Error loading site %s: %s" % (site.address, Debug.formatException(err)))
                 continue
             if merged_type:

--- a/plugins/Newsfeed/NewsfeedPlugin.py
+++ b/plugins/Newsfeed/NewsfeedPlugin.py
@@ -157,7 +157,7 @@ class UiWebsocketPlugin(object):
                     db_query.parts["LIMIT"] = "30"
 
                     res = site.storage.query(str(db_query), params)
-                except Exception, err:
+                except Exception as err:
                     self.log.error("%s feed query %s error: %s" % (address, name, Debug.formatException(err)))
                     stats.append({"site": site.address, "feed_name": name, "error": str(err), "query": query})
                     continue

--- a/plugins/PeerDb/PeerDbPlugin.py
+++ b/plugins/PeerDb/PeerDbPlugin.py
@@ -99,5 +99,5 @@ class ContentDbPlugin(object):
         for site in self.sites.values():
             try:
                 self.savePeers(site)
-            except Exception, err:
+            except Exception as err:
                 site.log.error("Save peer error: %s" % err)

--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -703,7 +703,7 @@ class UiWebsocketPlugin(object):
                 globe_data += [peer_location["lat"], peer_location["lon"], height]
 
             self.response(to, globe_data)
-        except Exception, err:
+        except Exception as err:
             self.log.debug("sidebarGetPeers error: %s" % Debug.formatException(err))
             self.response(to, {"error": err})
 

--- a/plugins/Stats/StatsPlugin.py
+++ b/plugins/Stats/StatsPlugin.py
@@ -487,7 +487,7 @@ class UiRequestPlugin(object):
             output("- %s" % name)
             try:
                 yield 1
-            except Exception, err:
+            except Exception as err:
                 output("<br><b>! Error: %s</b><br>" % err)
             taken = time.time() - s
             if taken > 0:

--- a/plugins/Trayicon/lib/notificationicon.py
+++ b/plugins/Trayicon/lib/notificationicon.py
@@ -562,7 +562,7 @@ class NotificationIcon(object):
                 ret = GetMessage(ctypes.pointer(message), 0, 0, 0)
                 TranslateMessage(ctypes.pointer(message))
                 DispatchMessage(ctypes.pointer(message))
-            except Exception, err:
+            except Exception as err:
                 # print "NotificationIcon error", err, message
                 message = MSG()
             time.sleep(0.125)
@@ -660,7 +660,7 @@ class NotificationIcon(object):
         time.sleep(0.2)
         try:
             Shell_NotifyIcon(NIM_DELETE, self.iconinfo)
-        except Exception, err:
+        except Exception as err:
             print "Icon remove error", err
         ctypes.windll.user32.DestroyWindow(self._hwnd)
         ctypes.windll.user32.DestroyIcon(self._hicon)

--- a/plugins/Zeroname/updater/zeroname_updater.py
+++ b/plugins/Zeroname/updater/zeroname_updater.py
@@ -19,7 +19,7 @@ def processNameOp(domain, value, test=False):
         return False
     try:
         data = json.loads(value)
-    except Exception, err:
+    except Exception as err:
         print "Json load error: %s" % err
         return False
     if "zeronet" not in data:
@@ -79,7 +79,7 @@ def processBlock(block_id, test=False):
                 if "scriptPubKey" in vout and "nameOp" in vout["scriptPubKey"] and "name" in vout["scriptPubKey"]["nameOp"]:
                     name_op = vout["scriptPubKey"]["nameOp"]
                     updated += processNameOp(name_op["name"].replace("d/", ""), name_op["value"], test)
-        except Exception, err:
+        except Exception as err:
             print "Error processing tx #%s %s" % (tx, err)
     print "Done in %.3fs (updated %s)." % (time.time() - s, updated)
     return updated
@@ -153,7 +153,7 @@ while 1:
     except socket.timeout:  # Timeout
         print ".",
         sys.stdout.flush()
-    except Exception, err:
+    except Exception as err:
         print "Exception", err.__class__, err
         time.sleep(5)
         rpc = AuthServiceProxy(rpc_auth, timeout=rpc_timeout)
@@ -192,7 +192,7 @@ while 1:
         except socket.timeout:  # Timeout
             print ".",
             sys.stdout.flush()
-        except Exception, err:
+        except Exception as err:
             print "Exception", err.__class__, err
             time.sleep(5)
             rpc = AuthServiceProxy(rpc_auth, timeout=rpc_timeout)

--- a/plugins/disabled-Multiuser/MultiuserPlugin.py
+++ b/plugins/disabled-Multiuser/MultiuserPlugin.py
@@ -9,7 +9,7 @@ import UserPlugin
 
 try:
     local_master_addresses = set(json.load(open("%s/users.json" % config.data_dir)).keys())  # Users in users.json
-except Exception, err:
+except Exception as err:
     local_master_addresses = set()
 
 

--- a/plugins/disabled-StemPort/StemPortPlugin.py
+++ b/plugins/disabled-StemPort/StemPortPlugin.py
@@ -67,7 +67,7 @@ class TorManagerPlugin(object):
                 controller.authenticate()
                 self.controller = controller
                 self.status = u"Connected (via Stem)"
-        except Exception, err:
+        except Exception as err:
             print("\n")
             traceback.print_exc()
             print("\n")
@@ -87,7 +87,7 @@ class TorManagerPlugin(object):
     def resetCircuits(self):
         try:
             self.controller.signal(Signal.NEWNYM)
-        except Exception, err:
+        except Exception as err:
             self.status = u"Stem reset circuits error (%s)" % err
             self.log.error("Stem reset circuits error: %s" % err)
 
@@ -105,7 +105,7 @@ class TorManagerPlugin(object):
 
             return (service.service_id, service.private_key)
 
-        except Exception, err:
+        except Exception as err:
             self.status = u"AddOnion error (Stem: %s)" % err
             self.log.error("Failed to create hidden service with Stem: " + err)
             return False
@@ -115,7 +115,7 @@ class TorManagerPlugin(object):
         try:
             self.controller.remove_ephemeral_hidden_service(address)
             return True
-        except Exception, err:
+        except Exception as err:
             self.status = u"DelOnion error (Stem: %s)" % err
             self.log.error("Stem failed to delete %s.onion: %s" % (address, err))
             self.disconnect() # Why?

--- a/src/Connection/Connection.py
+++ b/src/Connection/Connection.py
@@ -144,7 +144,7 @@ class Connection(object):
                 self.sock.do_handshake()
                 self.crypt = "tls-rsa"
                 self.sock_wrapped = True
-            except Exception, err:
+            except Exception as err:
                 if not config.force_encryption:
                     self.log("Crypt connection error: %s, adding ip %s as broken ssl." % (err, self.ip))
                     self.server.broken_ssl_ips[self.ip] = True
@@ -175,7 +175,7 @@ class Connection(object):
                     self.sock = CryptConnection.manager.wrapSocket(self.sock, "tls-rsa", True)
                     self.sock_wrapped = True
                     self.crypt = "tls-rsa"
-            except Exception, err:
+            except Exception as err:
                 self.log("Socket peek error: %s" % Debug.formatException(err))
         self.messageLoop()
 
@@ -295,7 +295,7 @@ class Connection(object):
                 self.incomplete_buff_recv += 1
                 self.bytes_recv += buff_len
                 self.server.bytes_recv += buff_len
-        except Exception, err:
+        except Exception as err:
             self.log("Stream read error: %s" % Debug.formatException(err))
 
         if config.debug_socket:
@@ -457,7 +457,7 @@ class Connection(object):
             try:
                 self.sock = CryptConnection.manager.wrapSocket(self.sock, self.crypt, server, cert_pin=self.cert_pin)
                 self.sock_wrapped = True
-            except Exception, err:
+            except Exception as err:
                 if not config.force_encryption:
                     self.log("Crypt connection error: %s, adding ip %s as broken ssl." % (err, self.ip))
                     self.server.broken_ssl_ips[self.ip] = True
@@ -507,7 +507,7 @@ class Connection(object):
                 message = None
                 with self.send_lock:
                     self.sock.sendall(data)
-        except Exception, err:
+        except Exception as err:
             self.close("Send error: %s (cmd: %s)" % (err, stat_key))
             return False
         self.last_sent_time = time.time()
@@ -558,7 +558,7 @@ class Connection(object):
         with gevent.Timeout(10.0, False):
             try:
                 response = self.request("ping")
-            except Exception, err:
+            except Exception as err:
                 self.log("Ping error: %s" % Debug.formatException(err))
         if response and "body" in response and response["body"] == "Pong!":
             self.last_ping_delay = time.time() - s
@@ -589,7 +589,7 @@ class Connection(object):
             if self.sock:
                 self.sock.shutdown(gevent.socket.SHUT_WR)
                 self.sock.close()
-        except Exception, err:
+        except Exception as err:
             if config.debug_socket:
                 self.log("Close error: %s" % err)
 

--- a/src/Connection/ConnectionServer.py
+++ b/src/Connection/ConnectionServer.py
@@ -84,13 +84,13 @@ class ConnectionServer(object):
             self.stream_server = StreamServer(
                 (self.ip, self.port), self.handleIncomingConnection, spawn=self.pool, backlog=100
             )
-        except Exception, err:
+        except Exception as err:
             self.log.info("StreamServer bind error: %s" % err)
 
     def listen(self):
         try:
             self.stream_server.serve_forever()
-        except Exception, err:
+        except Exception as err:
             self.log.info("StreamServer listen error: %s" % err)
 
     def stop(self):
@@ -179,7 +179,7 @@ class ConnectionServer(object):
                     connection.close("Connection event return error")
                     raise Exception("Connection event return error")
 
-            except Exception, err:
+            except Exception as err:
                 connection.close("%s Connect error: %s" % (ip, Debug.formatException(err)))
                 raise err
 

--- a/src/Content/ContentDb.py
+++ b/src/Content/ContentDb.py
@@ -19,7 +19,7 @@ class ContentDb(Db):
             foreign_key_error = self.execute("PRAGMA foreign_key_check").fetchone()
             if foreign_key_error:
                 raise Exception("Database foreign key error: %s" % foreign_key_error)
-        except Exception, err:
+        except Exception as err:
             self.log.error("Error loading content.db: %s, rebuilding..." % Debug.formatException(err))
             self.close()
             os.unlink(path)  # Remove and try again

--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -74,7 +74,7 @@ class ContentManager(object):
                             return [], []
 
                 new_content = json.load(open(content_path))
-            except Exception, err:
+            except Exception as err:
                 self.log.warning("%s load error: %s" % (content_path, Debug.formatException(err)))
                 return [], []
         else:
@@ -115,7 +115,7 @@ class ContentManager(object):
                             self.optionalRemoved(file_inner_path, old_hash_id, old_content["files_optional"][relative_path]["size"])
                             self.optionalDelete(file_inner_path)
                             self.log.debug("Deleted changed optional file: %s" % file_inner_path)
-                        except Exception, err:
+                        except Exception as err:
                             self.log.debug("Error deleting file %s: %s" % (file_inner_path, Debug.formatException(err)))
                 else:  # The file is not in the old content
                     if self.site.isDownloadable(file_inner_path):
@@ -151,7 +151,7 @@ class ContentManager(object):
                                 self.site.storage.delete(file_inner_path)
 
                             self.log.debug("Deleted file: %s" % file_inner_path)
-                        except Exception, err:
+                        except Exception as err:
                             self.log.debug("Error deleting file %s: %s" % (file_inner_path, Debug.formatException(err)))
 
                     # Cleanup empty dirs
@@ -165,7 +165,7 @@ class ContentManager(object):
                                 self.site.storage.deleteDir(root_inner_path)
                                 # Remove from tree dict to reflect changed state
                                 tree[os.path.dirname(root)][0].remove(os.path.basename(root))
-                            except Exception, err:
+                            except Exception as err:
                                 self.log.debug("Error deleting empty directory %s: %s" % (root_inner_path, err))
 
             # Check archived
@@ -255,7 +255,7 @@ class ContentManager(object):
                 self.has_optional_files = True
             # Update the content
             self.contents[content_inner_path] = new_content
-        except Exception, err:
+        except Exception as err:
             self.log.warning("%s parse error: %s" % (content_inner_path, Debug.formatException(err)))
             return [], []  # Content.json parse error
 
@@ -282,7 +282,7 @@ class ContentManager(object):
                 content.get("files", {}),
                 **content.get("files_optional", {})
             )
-        except Exception, err:
+        except Exception as err:
             self.log.debug("Error loading %s for removeContent: %s" % (inner_path, Debug.formatException(err)))
             files = {}
         files["content.json"] = True
@@ -292,16 +292,16 @@ class ContentManager(object):
             try:
                 self.site.storage.delete(file_inner_path)
                 self.log.debug("Deleted file: %s" % file_inner_path)
-            except Exception, err:
+            except Exception as err:
                 self.log.debug("Error deleting file %s: %s" % (file_inner_path, err))
         try:
             self.site.storage.deleteDir(inner_dir)
-        except Exception, err:
+        except Exception as err:
             self.log.debug("Error deleting dir %s: %s" % (inner_dir, err))
 
         try:
             del self.contents[inner_path]
-        except Exception, err:
+        except Exception as err:
             self.log.debug("Error key from contents: %s" % inner_path)
 
     # Get total size of site
@@ -775,7 +775,7 @@ class ContentManager(object):
         try:
             cert_subject = "%s#%s/%s" % (rules["user_address"], content["cert_auth_type"], name)
             result = CryptBitcoin.verify(cert_subject, cert_address, content["cert_sign"])
-        except Exception, err:
+        except Exception as err:
             raise VerifyError("Certificate verify error: %s" % err)
         return result
 
@@ -944,7 +944,7 @@ class ContentManager(object):
                     else:
                         raise VerifyError("Invalid old-style sign")
 
-            except Exception, err:
+            except Exception as err:
                 self.log.warning("%s: verify sign error: %s" % (inner_path, Debug.formatException(err)))
                 raise err
 

--- a/src/Crypt/CryptBitcoin.py
+++ b/src/Crypt/CryptBitcoin.py
@@ -10,7 +10,7 @@ try:
         raise Exception("Disabled by config")
     from lib.opensslVerify import opensslVerify
     logging.info("OpenSSL loaded, version: %s" % opensslVerify.openssl_version)
-except Exception, err:
+except Exception as err:
     logging.info("OpenSSL load failed: %s, falling back to slow bitcoin verify" % err)
     opensslVerify = None
 

--- a/src/Db/Db.py
+++ b/src/Db/Db.py
@@ -149,7 +149,7 @@ class Db(object):
         if not self.db_keyvalues:  # Get db keyvalues
             try:
                 res = self.execute("SELECT * FROM keyvalue WHERE json_id=0")  # json_id = 0 is internal keyvalues
-            except sqlite3.OperationalError, err:  # Table not exist
+            except sqlite3.OperationalError as err:  # Table not exist
                 self.log.debug("Query error: %s" % err)
                 return False
 
@@ -260,7 +260,7 @@ class Db(object):
                     data = json.load(helper.limitedGzipFile(fileobj=file))
                 else:
                     data = json.load(file)
-        except Exception, err:
+        except Exception as err:
             self.log.debug("Json file %s load error: %s" % (file_path, err))
             data = {}
 

--- a/src/Debug/Debug.py
+++ b/src/Debug/Debug.py
@@ -64,7 +64,7 @@ gevent.spawn(testBlock)
 if __name__ == "__main__":
     try:
         print 1 / 0
-    except Exception, err:
+    except Exception as err:
         print type(err).__name__
         print "1/0 error: %s" % formatException(err)
 
@@ -74,13 +74,13 @@ if __name__ == "__main__":
     import json
     try:
         loadJson()
-    except Exception, err:
+    except Exception as err:
         print err
         print "Json load error: %s" % formatException(err)
 
     try:
         raise Notify("nothing...")
-    except Exception, err:
+    except Exception as err:
         print "Notify: %s" % formatException(err)
 
     loadJson()

--- a/src/Debug/DebugHook.py
+++ b/src/Debug/DebugHook.py
@@ -16,7 +16,7 @@ def shutdown():
                 gevent.spawn(sys.modules["main"].file_server.stop)
             if "ui_server" in dir(sys.modules["main"]):
                 gevent.spawn(sys.modules["main"].ui_server.stop)
-        except Exception, err:
+        except Exception as err:
             print "Proper shutdown error: %s" % err
             sys.exit(0)
     else:

--- a/src/Debug/DebugReloader.py
+++ b/src/Debug/DebugReloader.py
@@ -10,7 +10,7 @@ if config.debug:  # Only load pyfilesytem if using debug mode
         pyfilesystem = OSFS("src")
         pyfilesystem_plugins = OSFS("plugins")
         logging.debug("Pyfilesystem detected, source code autoreload enabled")
-    except Exception, err:
+    except Exception as err:
         pyfilesystem = False
 else:
     pyfilesystem = False
@@ -34,7 +34,7 @@ class DebugReloader:
             time.sleep(1)  # Wait for .pyc compiles
             pyfilesystem.add_watcher(self.changed, path=self.directory, events=None, recursive=recursive)
             pyfilesystem_plugins.add_watcher(self.changed, path=self.directory, events=None, recursive=recursive)
-        except Exception, err:
+        except Exception as err:
             print "File system watcher failed: %s (on linux pyinotify not gevent compatible yet :( )" % err
 
     def changed(self, evt):

--- a/src/File/FileRequest.py
+++ b/src/File/FileRequest.py
@@ -117,7 +117,7 @@ class FileRequest(object):
 
         try:
             content = json.loads(params["body"])
-        except Exception, err:
+        except Exception as err:
             self.log.debug("Update for %s is invalid JSON: %s" % (inner_path, err))
             self.response({"error": "File invalid JSON"})
             self.connection.badAction(5)
@@ -130,7 +130,7 @@ class FileRequest(object):
         else:
             try:
                 valid = site.content_manager.verifyFile(inner_path, content)
-            except Exception, err:
+            except Exception as err:
                 self.log.debug("Update for %s is invalid: %s" % (inner_path, err))
                 valid = False
 
@@ -250,10 +250,10 @@ class FileRequest(object):
 
             return {"bytes_sent": bytes_sent, "file_size": file_size, "location": params["location"]}
 
-        except RequestError, err:
+        except RequestError as err:
             self.log.debug("GetFile %s %s request error: %s" % (self.connection, params["inner_path"], Debug.formatException(err)))
             self.response({"error": "File read error: %s" % err})
-        except Exception, err:
+        except Exception as err:
             if config.verbose:
                 self.log.debug("GetFile read error: %s" % Debug.formatException(err))
             self.response({"error": "File read error"})

--- a/src/File/FileServer.py
+++ b/src/File/FileServer.py
@@ -184,7 +184,7 @@ class FileServer(ConnectionServer):
             data = urllib2.urlopen("https://portchecker.co/check", "port=%s" % port, timeout=20.0).read()
             message = re.match('.*<div id="results-wrapper">(.*?)</div>', data, re.DOTALL).group(1)
             message = re.sub("<.*?>", "", message.replace("<br>", " ").replace("&nbsp;", " ").strip())  # Strip http tags
-        except Exception, err:
+        except Exception as err:
             return {"result": None, "message": Debug.formatException(err)}
 
         if "open" not in message:
@@ -217,7 +217,7 @@ class FileServer(ConnectionServer):
             data = urllib2.urlopen("http://www.canyouseeme.org/", "port=%s" % port, timeout=20.0).read()
             message = re.match('.*<p style="padding-left:15px">(.*?)</p>', data, re.DOTALL).group(1)
             message = re.sub("<.*?>", "", message.replace("<br>", " ").replace("&nbsp;", " "))  # Strip http tags
-        except Exception, err:
+        except Exception as err:
             return {"result": None, "message": Debug.formatException(err)}
 
         if "Success" not in message:
@@ -396,7 +396,7 @@ class FileServer(ConnectionServer):
             try:
                 UpnpPunch.ask_to_close_port(self.port, protos=["TCP"])
                 self.log.info('Closed port via upnp.')
-            except (UpnpPunch.UpnpError, UpnpPunch.IGDError), err:
+            except (UpnpPunch.UpnpError, UpnpPunch.IGDError) as err:
                 self.log.info("Failed at attempt to use upnp to close port: %s" % err)
 
         return ConnectionServer.stop(self)

--- a/src/Peer/Peer.py
+++ b/src/Peer/Peer.py
@@ -93,7 +93,7 @@ class Peer(object):
                 self.connection = connection_server.getConnection(self.ip, self.port, site=self.site, is_tracker_connection=self.is_tracker_connection)
                 self.reputation += 1
                 self.connection.sites += 1
-            except Exception, err:
+            except Exception as err:
                 self.onConnectionError("Getting connection error")
                 self.log("Getting connection error: %s (connection_error: %s, hash_failed: %s)" %
                          (Debug.formatException(err), self.connection_error, self.hash_failed))
@@ -162,7 +162,7 @@ class Peer(object):
                     return res
                 else:
                     raise Exception("Invalid response: %s" % res)
-            except Exception, err:
+            except Exception as err:
                 if type(err).__name__ == "Notify":  # Greenlet killed by worker
                     self.log("Peer worker got killed: %s, aborting cmd: %s" % (err.message, cmd))
                     break

--- a/src/Plugin/PluginManager.py
+++ b/src/Plugin/PluginManager.py
@@ -48,7 +48,7 @@ class PluginManager:
             self.log.debug("Loading plugin: %s" % dir_name)
             try:
                 __import__(dir_name)
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Plugin %s load error: %s" % (dir_name, Debug.formatException(err)))
             if dir_name not in self.plugin_names:
                 self.plugin_names.append(dir_name)
@@ -74,7 +74,7 @@ class PluginManager:
                 else:
                     try:
                         reload(module)
-                    except Exception, err:
+                    except Exception as err:
                         self.log.error("Plugin %s reload error: %s" % (module_name, Debug.formatException(err)))
 
         self.loadPlugins()  # Load new plugins

--- a/src/Site/Site.py
+++ b/src/Site/Site.py
@@ -199,7 +199,7 @@ class Site(object):
                                 "Patched successfully: %s (diff: %.3fs, verify: %.3fs, write: %.3fs, on_done: %.3fs)" %
                                 (file_inner_path, time_diff, time_verify, time_write, time_on_done)
                             )
-                    except Exception, err:
+                    except Exception as err:
                         self.log.debug("Failed to patch %s: %s" % (file_inner_path, err))
                         diff_success = False
 
@@ -518,7 +518,7 @@ class Site(object):
                         })
                     if result:
                         break
-                except Exception, err:
+                except Exception as err:
                     self.log.error("Publish error: %s" % Debug.formatException(err))
                     result = {"exception": Debug.formatException(err)}
 

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -186,7 +186,7 @@ class SiteAnnouncer(object):
                 peers = handler(address, mode=mode, num_want=num_want)
             else:
                 raise AnnounceError("Unknown protocol: %s" % protocol)
-        except Exception, err:
+        except Exception as err:
             self.site.log.warning("Tracker %s announce failed: %s in mode %s" % (tracker, str(err).decode("utf8", "ignore"), mode))
             error = err
 

--- a/src/Site/SiteManager.py
+++ b/src/Site/SiteManager.py
@@ -40,7 +40,7 @@ class SiteManager(object):
                     try:
                         site = Site(address, settings=settings)
                         site.content_manager.contents.get("content.json")
-                    except Exception, err:
+                    except Exception as err:
                         self.log.debug("Error loading site %s: %s" % (address, err))
                         continue
                     self.sites[address] = site

--- a/src/Site/SiteStorage.py
+++ b/src/Site/SiteStorage.py
@@ -59,7 +59,7 @@ class SiteStorage(object):
     def getDbSchema(self):
         try:
             schema = self.loadJson("dbschema.json")
-        except Exception, err:
+        except Exception as err:
             raise Exception("dbschema.json is not a valid JSON: %s" % err)
         return schema
 
@@ -129,7 +129,7 @@ class SiteStorage(object):
             self.log.info("Deleting %s" % db_path)
             try:
                 os.unlink(db_path)
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Delete error: %s" % err)
 
         db = self.openDb()
@@ -150,7 +150,7 @@ class SiteStorage(object):
                 try:
                     if self.updateDbFile(file_inner_path, file=open(file_path, "rb"), cur=cur):
                         found += 1
-                except Exception, err:
+                except Exception as err:
                     self.log.error("Error importing %s: %s" % (file_inner_path, Debug.formatException(err)))
                 if found and found % 100 == 0:
                     self.site.messageWebsocket(
@@ -181,7 +181,7 @@ class SiteStorage(object):
             self.event_db_busy.get()  # Wait for event
         try:
             res = self.getDb().execute(query, params)
-        except sqlite3.DatabaseError, err:
+        except sqlite3.DatabaseError as err:
             if err.__class__.__name__ == "DatabaseError":
                 self.log.error("Database error: %s, query: %s, try to rebuilding it..." % (err, query))
                 self.rebuildDb()
@@ -240,7 +240,7 @@ class SiteStorage(object):
                 os.rename(self.getPath(inner_path_before), self.getPath(inner_path_after))
                 err = None
                 break
-            except Exception, err:
+            except Exception as err:
                 self.log.error("%s rename error: %s (retry #%s)" % (inner_path_before, err, retry))
                 time.sleep(0.1 + retry)
         if err:
@@ -297,7 +297,7 @@ class SiteStorage(object):
                 self.log.debug("Loading json file to db: %s (file: %s)" % (inner_path, file))
             try:
                 self.updateDbFile(inner_path, file)
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Json %s load error: %s" % (inner_path, Debug.formatException(err)))
                 self.closeDb()
 
@@ -418,7 +418,7 @@ class SiteStorage(object):
                 else:
                     try:
                         ok = self.site.content_manager.verifyFile(file_inner_path, open(file_path, "rb"))
-                    except Exception, err:
+                    except Exception as err:
                         ok = False
 
                 if not ok:
@@ -451,7 +451,7 @@ class SiteStorage(object):
                 else:
                     try:
                         ok = self.site.content_manager.verifyFile(file_inner_path, open(file_path, "rb"))
-                    except Exception, err:
+                    except Exception as err:
                         ok = False
 
                 if ok:
@@ -518,7 +518,7 @@ class SiteStorage(object):
                 db_path = self.getPath(schema["db_file"])
                 if os.path.isfile(db_path):
                     os.unlink(db_path)
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Db file delete error: %s" % err)
 
         for inner_path in files:
@@ -528,7 +528,7 @@ class SiteStorage(object):
                     try:
                         os.unlink(path)
                         break
-                    except Exception, err:
+                    except Exception as err:
                         self.log.error(u"Error removing %s: %s, try #%s" % (inner_path, err, retry))
                     time.sleep(float(retry) / 10)
             self.onUpdated(inner_path, False)

--- a/src/Test/BenchmarkSsl.py
+++ b/src/Test/BenchmarkSsl.py
@@ -46,7 +46,7 @@ def handle(sock_raw, addr):
                 )
             else:
                 sock.sendall(data)
-    except Exception, err:
+    except Exception as err:
         print err
     try:
         sock.shutdown(gevent.socket.SHUT_WR)

--- a/src/Test/TestTor.py
+++ b/src/Test/TestTor.py
@@ -58,7 +58,7 @@ class TestTor:
                 connection = file_server.getConnection(address+".onion", 1544)
                 if connection:
                     break
-            except Exception, err:
+            except Exception as err:
                 continue
         assert connection.handshake
         assert not connection.handshake["peer_id"]  # No peer_id for Tor connections

--- a/src/Test/conftest.py
+++ b/src/Test/conftest.py
@@ -207,7 +207,7 @@ def browser(request):
         def quit():
             browser.quit()
         request.addfinalizer(quit)
-    except Exception, err:
+    except Exception as err:
         raise pytest.skip("Test requires selenium + chromedriver: %s" % err)
     return browser
 
@@ -216,7 +216,7 @@ def browser(request):
 def site_url():
     try:
         urllib.urlopen(SITE_URL).read()
-    except Exception, err:
+    except Exception as err:
         raise pytest.skip("Test requires zeronet client running: %s" % err)
     return SITE_URL
 
@@ -238,7 +238,7 @@ def file_server(request):
             conn = file_server.getConnection("127.0.0.1", 1544)
             conn.close()
             break
-        except Exception, err:
+        except Exception as err:
             print err
     assert file_server.running
 
@@ -275,7 +275,7 @@ def tor_manager():
         tor_manager = TorManager()
         assert tor_manager.connect()
         tor_manager.startOnions()
-    except Exception, err:
+    except Exception as err:
         raise pytest.skip("Test requires Tor with ControlPort: %s, %s" % (config.tor_controller, err))
     return tor_manager
 

--- a/src/Tor/TorManager.py
+++ b/src/Tor/TorManager.py
@@ -65,7 +65,7 @@ class TorManager(object):
             if not self.connect():
                 raise Exception("No connection")
             self.log.debug("Tor proxy port %s check ok" % config.tor_proxy)
-        except Exception, err:
+        except Exception as err:
             if sys.platform.startswith("win"):
                 self.log.info(u"Starting self-bundled Tor, due to Tor proxy port %s check error: %s" % (config.tor_proxy, err))
             else:
@@ -110,7 +110,7 @@ class TorManager(object):
                         break
                 # Terminate on exit
                 atexit.register(self.stopTor)
-            except Exception, err:
+            except Exception as err:
                 self.log.error(u"Error starting Tor client: %s" % Debug.formatException(str(err).decode("utf8", "ignore")))
                 self.enabled = False
         self.starting = False
@@ -125,7 +125,7 @@ class TorManager(object):
         try:
             if self.isSubprocessRunning():
                 self.request("SIGNAL SHUTDOWN")
-        except Exception, err:
+        except Exception as err:
             self.log.error("Error stopping Tor: %s" % err)
 
     def downloadTor(self):
@@ -213,7 +213,7 @@ class TorManager(object):
                 self.event_started.set(True)
                 self.connecting = False
                 self.conn = conn
-        except Exception, err:
+        except Exception as err:
             self.conn = None
             self.setStatus(u"Error (%s)" % str(err).decode("utf8", "ignore"))
             self.log.error(u"Tor controller connect error: %s" % Debug.formatException(str(err).decode("utf8", "ignore")))
@@ -294,7 +294,7 @@ class TorManager(object):
                 while not back.endswith("250 OK\r\n"):
                     back += conn.recv(1024 * 64).decode("utf8", "ignore")
                 break
-            except Exception, err:
+            except Exception as err:
                 self.log.error("Tor send error: %s, reconnecting..." % err)
                 self.disconnect()
                 time.sleep(1)

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -698,7 +698,7 @@ class UiRequest(object):
             if site:  # Correct wrapper key
                 try:
                     user = self.getCurrentUser()
-                except Exception, err:
+                except Exception as err:
                     self.log.error("Error in data/user.json: %s" % err)
                     return self.error500()
                 if not user:

--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -30,7 +30,7 @@ class UiWSGIHandler(WSGIHandler):
                 ws_handler = WebSocketHandler(*self.args, **self.kwargs)
                 ws_handler.__dict__ = self.__dict__  # Match class variables
                 ws_handler.run_application()
-            except Exception, err:
+            except Exception as err:
                 logging.error("UiWSGIHandler websocket error: %s" % Debug.formatException(err))
                 if config.debug:  # Allow websocket errors to appear on /Debug
                     import sys
@@ -38,7 +38,7 @@ class UiWSGIHandler(WSGIHandler):
         else:  # Standard HTTP request
             try:
                 super(UiWSGIHandler, self).run_application()
-            except Exception, err:
+            except Exception as err:
                 logging.error("UiWSGIHandler error: %s" % Debug.formatException(err))
                 if config.debug:  # Allow websocket errors to appear on /Debug
                     import sys
@@ -102,7 +102,7 @@ class UiServer:
         else:  # Catch and display the error
             try:
                 return ui_request.route(path)
-            except Exception, err:
+            except Exception as err:
                 logging.debug("UiRequest error: %s" % Debug.formatException(err))
                 return ui_request.error500("Err: %s" % Debug.formatException(err))
 
@@ -129,7 +129,7 @@ class UiServer:
             try:
                 from werkzeug.debug import DebuggedApplication
                 handler = DebuggedApplication(self.handleRequest, evalex=True)
-            except Exception, err:
+            except Exception as err:
                 self.log.info("%s: For debugging please download Werkzeug (http://werkzeug.pocoo.org/)" % err)
                 from Debug import DebugReloader
         self.log.write = lambda msg: self.log.debug(msg.strip())  # For Wsgi access.log
@@ -155,7 +155,7 @@ class UiServer:
         self.afterStarted()
         try:
             self.server.serve_forever()
-        except Exception, err:
+        except Exception as err:
             self.log.error("Web interface bind error, must be running already, exiting.... %s" % err)
             sys.modules["main"].file_server.stop()
         self.log.debug("Stopped.")
@@ -175,7 +175,7 @@ class UiServer:
                 # sock._sock.close()
                 # sock.close()
                 sock_closed += 1
-            except Exception, err:
+            except Exception as err:
                 self.log.debug("Http connection close error: %s" % err)
         self.log.debug("Socket closed: %s" % sock_closed)
         time.sleep(0.1)

--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -54,7 +54,7 @@ class UiWebsocket(object):
             else:
                 try:
                     self.addHomepageNotifications()
-                except Exception, err:
+                except Exception as err:
                     self.log.error("Uncaught Exception: " + Debug.formatException(err))
 
         for notification in self.site.notifications:  # Send pending notification messages
@@ -72,7 +72,7 @@ class UiWebsocket(object):
                     break
                 else:
                     message = ws.receive()
-            except Exception, err:
+            except Exception as err:
                 self.log.error("WebSocket receive error: %s" % Debug.formatException(err))
                 break
 
@@ -80,7 +80,7 @@ class UiWebsocket(object):
                 try:
                     req = json.loads(message)
                     self.handleRequest(req)
-                except Exception, err:
+                except Exception as err:
                     if config.debug:  # Allow websocket errors to appear on /Debug
                         sys.modules["main"].DebugHook.handleError()
                     self.log.error("WebSocket handleRequest error: %s \n %s" % (Debug.formatException(err), message))
@@ -212,7 +212,7 @@ class UiWebsocket(object):
                 message = self.send_queue.pop(0)
                 self.ws.send(json.dumps(message))
                 self.state["sending"] = False
-        except Exception, err:
+        except Exception as err:
             self.log.debug("Websocket send error: %s" % Debug.formatException(err))
             self.state["sending"] = False
 
@@ -229,7 +229,7 @@ class UiWebsocket(object):
                 result = func(*args, **kwargs)
                 if result is not None:
                     self.response(args[0], result)
-            except Exception, err:
+            except Exception as err:
                 if config.debug:  # Allow websocket errors to appear on /Debug
                     sys.modules["main"].DebugHook.handleError()
                 self.log.error("WebSocket handleRequest error: %s" % Debug.formatException(err))
@@ -595,7 +595,7 @@ class UiWebsocket(object):
                     shutil.copyfileobj(f_old, f_new)
 
             self.site.storage.write(inner_path, content)
-        except Exception, err:
+        except Exception as err:
             self.log.error("File write error: %s" % Debug.formatException(err))
             return self.response(to, {"error": "Write error: %s" % Debug.formatException(err)})
 
@@ -630,7 +630,7 @@ class UiWebsocket(object):
         if need_delete:
             try:
                 self.site.storage.delete(inner_path)
-            except Exception, err:
+            except Exception as err:
                 self.log.error("File delete error: %s" % err)
                 return self.response(to, {"error": "Delete error: %s" % err})
 
@@ -670,7 +670,7 @@ class UiWebsocket(object):
         rows = []
         try:
             res = self.site.storage.query(query, params)
-        except Exception, err:  # Response the error to client
+        except Exception as err:  # Response the error to client
             self.log.error("DbQuery error: %s" % err)
             return self.response(to, {"error": str(err)})
         # Convert result to dict
@@ -687,7 +687,7 @@ class UiWebsocket(object):
                 with gevent.Timeout(timeout):
                     self.site.needFile(inner_path, priority=6)
             body = self.site.storage.read(inner_path, "rb")
-        except Exception, err:
+        except Exception as err:
             self.log.error("%s fileGet error: %s" % (inner_path, err))
             body = None
         if body and format == "base64":
@@ -699,7 +699,7 @@ class UiWebsocket(object):
         try:
             with gevent.Timeout(timeout):
                 self.site.needFile(inner_path, priority=6)
-        except Exception, err:
+        except Exception as err:
             return self.response(to, {"error": str(err)})
         return self.response(to, "ok")
 
@@ -747,7 +747,7 @@ class UiWebsocket(object):
                 )
             else:
                 self.response(to, "Not changed")
-        except Exception, err:
+        except Exception as err:
             self.log.error("CertAdd error: Exception - %s (%s)" % (err.message, Debug.formatException(err)))
             self.response(to, {"error": err.message})
 

--- a/src/Worker/Worker.py
+++ b/src/Worker/Worker.py
@@ -80,7 +80,7 @@ class Worker(object):
             task["workers_num"] += 1
             try:
                 buff = self.peer.getFile(site.address, task["inner_path"], task["size"])
-            except Exception, err:
+            except Exception as err:
                 self.manager.log.debug("%s: getFile error: %s" % (self.key, err))
                 buff = None
             if self.running is False:  # Worker no longer needed or got killed
@@ -91,7 +91,7 @@ class Worker(object):
             if buff:  # Download ok
                 try:
                     correct = site.content_manager.verifyFile(task["inner_path"], buff)
-                except Exception, err:
+                except Exception as err:
                     correct = False
             else:  # Download error
                 err = "Download failed"

--- a/src/main.py
+++ b/src/main.py
@@ -196,7 +196,7 @@ class Actions(object):
                 privatekey = getpass.getpass("Private key (input hidden):")
         try:
             succ = site.content_manager.sign(inner_path=inner_path, privatekey=privatekey, update_changed_files=True, remove_missing_optional=remove_missing_optional)
-        except Exception, err:
+        except Exception as err:
             logging.error("Sign error: %s" % Debug.formatException(err))
             succ = False
         if succ and publish:
@@ -220,7 +220,7 @@ class Actions(object):
                 file_correct = site.content_manager.verifyFile(
                     content_inner_path, site.storage.open(content_inner_path, "rb"), ignore_same=False
                 )
-            except Exception, err:
+            except Exception as err:
                 file_correct = False
 
             if file_correct is True:
@@ -486,7 +486,7 @@ class Actions(object):
         try:
             res = peer.request(cmd, parameters)
             print json.dumps(res, indent=2, ensure_ascii=False)
-        except Exception, err:
+        except Exception as err:
             print "Unknown response (%s): %s" % (err, res)
 
     def getConfig(self):

--- a/src/util/Platform.py
+++ b/src/util/Platform.py
@@ -19,6 +19,6 @@ def setMaxfilesopened(limit):
                 resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
                 return True
 
-    except Exception, err:
+    except Exception as err:
         logging.error("Failed to modify max files open limit: %s" % err)
         return False

--- a/src/util/SslPatch.py
+++ b/src/util/SslPatch.py
@@ -29,7 +29,7 @@ def getLibraryPath():
         try:
             lib_dir = os.environ["ANDROID_APP_PATH"] + "/../../lib"
             return [lib for lib in os.listdir(lib_dir) if "crypto" in lib][0]
-        except Exception, err:
+        except Exception as err:
             logging.debug("OpenSSL lib not found in: %s (%s)" % (lib_dir, err))
 
     return (
@@ -49,7 +49,7 @@ def disableSSLCompression():
     try:
         openssl = openLibrary()
         openssl.SSL_COMP_get_compression_methods.restype = ctypes.c_void_p
-    except Exception, err:
+    except Exception as err:
         logging.debug("Disable SSL compression failed: %s (normal on Windows)" % err)
         return False
 
@@ -61,7 +61,7 @@ def disableSSLCompression():
 if config.disable_sslcompression:
     try:
         disableSSLCompression()
-    except Exception, err:
+    except Exception as err:
         logging.debug("Error disabling SSL compression: %s" % err)
 
 
@@ -130,7 +130,7 @@ try:
     if not hasattr(gevent.ssl, "SSLContext"):
         gevent.ssl.SSLContext = __ssl__.SSLContext
         logging.debug("Missing SSLContext, readded.")
-except Exception, err:
+except Exception as err:
     pass
 
 # Redirect insecure SSLv2 and v3

--- a/src/util/helper.py
+++ b/src/util/helper.py
@@ -25,7 +25,7 @@ def atomicWrite(dest, content, mode="w"):
         os.rename(dest + "-tmpnew", dest)
         os.unlink(dest + "-tmpold")  # Remove old file
         return True
-    except Exception, err:
+    except Exception as err:
         from Debug import Debug
         logging.error(
             "File %s write failed: %s, reverting..." %
@@ -63,7 +63,7 @@ def getFreeSpace():
                 ctypes.c_wchar_p(config.data_dir), None, None, ctypes.pointer(free_space_pointer)
             )
             free_space = free_space_pointer.value
-        except Exception, err:
+        except Exception as err:
             logging.error("GetFreeSpace error: %s" % err)
     return free_space
 

--- a/tools/python3_check.sh
+++ b/tools/python3_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+basedir="$(cd `dirname $0`; pwd)"
+rootdir="$(cd ${basedir}/../.. ; pwd)"
+
+declare -a patterns=(
+                     "except\s.*, e.*:"
+		     )
+declare -a py2_syntax=(
+                     "','"
+                     )
+declare -a py2_3_syntax=(
+                     "exception with 'as'"
+                     )
+
+for i in "${!patterns[@]}"
+do
+    bad_file_found=$(grep -Pr -e "${patterns[$i]}" plugins/ src/ *.py | grep -v '#.*\bNOCHECK\b.*' | sed -E 's/([^:]*)(:.*)/\1/' | sort -u | grep '.py$')
+
+    if [ -n "${bad_file_found}" ]
+    then
+        failed=yes
+        echo "** PY2/3 CHECK FAILED ** Please consider using ${py2_3_syntax[$i]}" over ${py2_syntax[$i]}" in file(s):"
+        echo "${bad_file_found}"
+    fi
+done
+if [[ -v failed ]]; then exit 1; else exit 0; fi

--- a/update.py
+++ b/update.py
@@ -33,10 +33,10 @@ def download():
             try:
                 zipdata = zipfile.ZipFile(data)
                 break  # Success
-            except Exception, err:
+            except Exception as err:
                 data.seek(0)
                 print "Unpack error", err, data.read(256)
-        except Exception, err:
+        except Exception as err:
             print "Error downloading update from %s: %s" % (url, err)
 
     if not zipdata:
@@ -115,7 +115,7 @@ def update():
 
             try:
                 open(dest_path, 'wb').write(data)
-            except Exception, err:
+            except Exception as err:
                 print dest_path, err
 
     print "Done."
@@ -136,6 +136,6 @@ if __name__ == "__main__":
 
     try:
         update()
-    except Exception, err:
+    except Exception as err:
         print "Update error: %s" % err
     raw_input("Press enter to exit")

--- a/zeronet.py
+++ b/zeronet.py
@@ -24,12 +24,12 @@ def main():
             try:
                 if "lib.opensslVerify" in sys.modules:
                     sys.modules["lib.opensslVerify"].opensslVerify.closeLibrary()
-            except Exception, err:
+            except Exception as err:
                 print "Error closing opensslVerify lib", err
             try:
                 if "lib.pyelliptic" in sys.modules:
                     sys.modules["lib.pyelliptic"].openssl.closeLibrary()
-            except Exception, err:
+            except Exception as err:
                 print "Error closing pyelliptic lib", err
 
             # Close lock file
@@ -38,10 +38,10 @@ def main():
             # Update
             try:
                 update.update()
-            except Exception, err:
+            except Exception as err:
                 print "Update error: %s" % err
 
-    except Exception, err:  # Prevent closing
+    except Exception as err:  # Prevent closing
         import traceback
         try:
             import logging
@@ -79,7 +79,7 @@ def main():
         try:
             print "Executing %s %s" % (sys.executable, args)
             os.execv(sys.executable, args)
-        except Exception, err:
+        except Exception as err:
             print "Execv error: %s" % err
         print "Bye."
 


### PR DESCRIPTION
Workflow:
- Py2 > Py2&3 Compatible > Py3

Process:
- Feature-oriented PRs (Feature-by-Feature migration)

Steps (5):
- Syntax Fixes: lists/iterators handling, exceptions, octal literals, etc.
- Semantic Fixes: Unicode literals, division, hybrid comparisons, etc.
- Env switch: add py3 & cut/keep py2 support
- More Fixes: fix remained bugs (because it's painful, you guessed it...you are damn right!)
- Cleanup (optional): get rid of compatible code such as Try/Except imports, TODOs, etc.

Challenges:
- Contributors may still write py2 code which will cause me rebasing my branch on master forever. That's why we need the `python3_checks.sh` file in place.
