### PR TITLE
Add support for tilde `~` in filenames.

### DIFF
--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -552,7 +552,7 @@ class ContentManager(object):
         elif len(relative_path) > 255:
             return False
         else:
-            return re.match("^[a-z\[\]\(\) A-Z0-9_@=\.\+-/]+$", relative_path)
+            return re.match("^[a-z\[\]\(\) A-Z0-9~_@=\.\+-/]+$", relative_path)
 
     def sanitizePath(self, inner_path):
         return re.sub("[^a-z\[\]\(\) A-Z0-9_@=\.\+-/]", "", inner_path)


### PR DESCRIPTION
(source: https://webpack.js.org/guides/code-splitting)

It appears that webpack (bundled w/ the VueJS CLI) will concatenate `chunk` names using the `~` to create one long "bundled" filename. This creates a problem when executing `isValidRelativePath` which DOES NOT allow `~`.

__An example error when signing:__
`Site:1... - [ERROR] Invalid filename: js/about~privacy~search.3c7ce85b.js`

A fix is to use the same name for each file/chunk, but then that breaks the optimizations of code splitting. Is there any reason NOT to permit tilde `~` as a valid filename character? _(NOTE: this may only be an issue if using vue-router)_