### PR TITLE
Fix atexit not working on SIGTERM

### DIFF
--- a/zeronet.py
+++ b/zeronet.py
@@ -11,7 +11,6 @@ def main():
 
     main = None
     try:
-        import atexit
         from signal import signal, SIGTERM
 
         signal(SIGTERM, lambda signum, stack_frame: sys.exit(0))

--- a/zeronet.py
+++ b/zeronet.py
@@ -11,9 +11,9 @@ def main():
 
     main = None
     try:
-        from signal import signal, SIGTERM
+        import signal
 
-        signal(SIGTERM, lambda signum, stack_frame: sys.exit(0))
+        signal.signal(signal.SIGTERM, lambda signum, stack_frame: sys.exit(0))
         
         app_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(app_dir)  # Change working dir to zeronet.py dir

--- a/zeronet.py
+++ b/zeronet.py
@@ -11,6 +11,11 @@ def main():
 
     main = None
     try:
+        import atexit
+        from signal import signal, SIGTERM
+
+        signal(SIGTERM, lambda signum, stack_frame: sys.exit(0))
+        
         app_dir = os.path.dirname(os.path.abspath(__file__))
         os.chdir(app_dir)  # Change working dir to zeronet.py dir
         sys.path.insert(0, os.path.join(app_dir, "src/lib"))  # External liblary directory


### PR DESCRIPTION
I am working on HorizonManager that manages the process of HorizonSpider and zeronet.
It would terminate zeronet by sending SIGTERM.
However, atexit won't work on SIGTERM.We have to manually call sys.exit to trigger atexit.