### PR TITLE
Zeroname fix waitforblock

### DIFF
--- a/plugins/Zeroname/updater/zeroname_updater.py
+++ b/plugins/Zeroname/updater/zeroname_updater.py
@@ -230,7 +230,10 @@ while 1:
             time.sleep(5)
             rpc = AuthServiceProxy(rpc_auth, timeout=rpc_timeout)
 
-    last_block = int(rpc.getinfo()["blocks"])
+    if node_version < 160000 :
+        last_block = int(rpc.getinfo()["blocks"])
+    else:
+        last_block = int(rpc.getblockchaininfo()["blocks"])
     should_publish = False
     for block_id in range(config["lastprocessed"] + 1, last_block + 1):
         if processBlock(block_id):

--- a/plugins/Zeroname/updater/zeroname_updater.py
+++ b/plugins/Zeroname/updater/zeroname_updater.py
@@ -216,7 +216,10 @@ while 1:
     while 1:
         try:
             time.sleep(1)
-            rpc.waitforblock()
+            if node_version < 160000 :
+                rpc.waitforblock()
+            else:
+                rpc.waitfornewblock()
             print "Found"
             break  # Block found
         except socket.timeout:  # Timeout


### PR DESCRIPTION
- [x] Replace `waitforblock` with `waitfornewblock` if Namecoin version is higher than 16.0
- [x] Also fix second call to `getinfo`; replace with `getblockchaininfo`if Namcoin version is higher than 16.0
- [x] Tested with Namecoin core 16.3 

Logs that show new block successfully processed :
```
- Waiting for new block
Found
Processing block #439917...
Checking 1 tx
Done in 0.013s (updated 0).
- Waiting for new block
```

Fix #1906