### PR TITLE
If no port defined in tracker url assume it is port 80

### DIFF
--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -177,6 +177,8 @@ class SiteAnnouncer(object):
         except ValueError as err:
             ip = address
             port = 80
+            if protocol.startswith("https"):
+                port = 443
         back = {}
         back["protocol"] = protocol
         back["address"] = address

--- a/src/Site/SiteAnnouncer.py
+++ b/src/Site/SiteAnnouncer.py
@@ -172,7 +172,11 @@ class SiteAnnouncer(object):
         if "://" not in tracker or not re.match("^[A-Za-z0-9:/\\.#-]+$", tracker):
             return None
         protocol, address = tracker.split("://", 1)
-        ip, port = address.rsplit(":", 1)
+        try:
+            ip, port = address.rsplit(":", 1)
+        except ValueError as err:
+            ip = address
+            port = 80
         back = {}
         back["protocol"] = protocol
         back["address"] = address


### PR DESCRIPTION
fix #1917

Added try and expect to avoid error throwing in case the tracker doesn't have a port in its url. It will assume the port is 80.
