### PR TITLE
Fix wrong module name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ rsa
 PySocks
 pyasn1
 websocket
-geventwebsocket
+gevent-websocket
 bencode
 coincurve
 python-bitcoinlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ PySocks
 pyasn1
 websocket
 gevent-websocket
-bencode
+bencode.py
 coincurve
 python-bitcoinlib
 maxminddb


### PR DESCRIPTION
`Exception: You probably meant to install and run gevent-websocket`