### PR TITLE
Fix "no module" error

### DIFF
--- a/src/util/SocksProxy.py
+++ b/src/util/SocksProxy.py
@@ -1,6 +1,6 @@
 import socket
 
-from lib.PySocks import socks
+import socks
 from Config import config
 
 def create_connection(address, timeout=None, source_address=None):


### PR DESCRIPTION
Since PySocks is added into requirements.txt, no need to `from...`