### PR TITLE
requirements: pyelliptic any version, websocket_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,46 @@ Decentralized websites using Bitcoin crypto and the BitTorrent network - https:/
 
 ## How to join
 
-* `sudo apt-get update`
-* `sudo apt-get install python3-pip`
-* `wget https://github.com/HelloZeroNet/ZeroNet/archive/py3.tar.gz`
-* `tar xvpfz py3.tar.gz`
-* `cd ZeroNet-py3`
-* Install required Python modules `sudo python3 -m pip install -r requirements.txt`
-* Start with `python3 zeronet.py`
-* Open http://127.0.0.1:43110/ in your browser
+### Install from package for your distribution
 
+* Arch Linux: [zeronet](https://aur.archlinux.org/zeronet.git), [zeronet-git](https://aur.archlinux.org/zeronet-git.git)
+* Gentoo:  [emerge repository](https://github.com/leycec/raiagent)
+* FreeBSD: zeronet
+* Whonix: [instructions](https://www.whonix.org/wiki/ZeroNet)
+
+### Install from source
+
+Fetch and extract the source:
+
+    wget https://github.com/HelloZeroNet/ZeroNet/archive/py3.tar.gz
+    tar xvpfz py3.tar.gz
+    cd ZeroNet-py3
+
+Install Python module dependencies either:
+
+* (Option A) into a [virtual env](https://virtualenv.readthedocs.org/en/latest/)
+
+    ```
+    virtualenv zeronet
+    source zeronet/bin/activate
+    python -m pip install -r requirements.txt
+    ```
+
+* (Option B) into the system (requires root), for example, on Debian/Ubuntu:
+
+    ```
+    sudo apt-get update
+    sudo apt-get install python3-pip
+    sudo python3 -m pip install -r requirements.txt
+    ```
+
+Start Zeronet:
+
+    python zeronet.py
+
+Open the ZeroHello landing page in your browser by navigating to:
+
+    http://127.0.0.1:43110/
 
 ## Current limitations
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pyelliptic==1.5.6
 rsa
 PySocks
 pyasn1
-websocket
+websocket_client
 gevent-websocket
 bencode.py
 coincurve


### PR DESCRIPTION
`pyelliptic` 1.5.8 works fine for me. Any particular reason it was frozen at 1.5.6?

`websocket` is likely not the package you are looking for -- the canonical websocket package is  `websocket_client`. `websocket_client` installs `/usr/lib/python3.7/site-packages/websocket/`

Btw, this looks like stale code:
```
$ grep -C2 -rnI 'from lib import websocket'
src/main.py-338-
src/main.py-339-    def getWebsocket(self, site):
src/main.py:340:        from lib import websocket
src/main.py-341-        ws = websocket.create_connection("ws://%s:%s/Websocket?wrapper_key=%s" % (config.ui_ip, config.ui_port, site.settings["wrapper_key"]))
src/main.py-342-        return ws
```
Unrelated: I also added links to distribution packages to the README. Distro packages are always preferred when they exist. Also, added installation into virtualenv because it's preferred and does not require root.

PS. I've updated zeronet-git Arch package on AUR to the Python 3 branch (it's supposed to be bleeding edge).
PPS. If I have some time I will try to package zeronet itself with setuptools (setup.py). It should be installable into site-packages and runnable with sources owned by root (like any other python application).