### PR TITLE
CryptMessage: base64 arg type byte-array; File: set error message before use

### DIFF
--- a/plugins/CryptMessage/CryptMessagePlugin.py
+++ b/plugins/CryptMessage/CryptMessagePlugin.py
@@ -75,7 +75,7 @@ class UiWebsocketPlugin(object):
         if text:
             encrypted = pyelliptic.Cipher(key, iv, 1, ciphername='aes-256-cbc').ciphering(text.encode("utf8"))
         else:
-            encrypted = ""
+            encrypted = b""
 
         res = [base64.b64encode(item).decode("utf8") for item in [key, iv, encrypted]]
         self.response(to, res)

--- a/src/File/FileRequest.py
+++ b/src/File/FileRequest.py
@@ -133,6 +133,7 @@ class FileRequest(object):
                 valid = site.content_manager.verifyFile(inner_path, content)
             except Exception as err:
                 self.log.debug("Update for %s is invalid: %s" % (inner_path, err))
+                error = err
                 valid = False
 
         if valid is True:  # Valid and changed
@@ -182,7 +183,7 @@ class FileRequest(object):
             self.connection.badAction()
 
         else:  # Invalid sign or sha hash
-            self.response({"error": "File invalid: %s" % err})
+            self.response({"error": "File %s invalid: %s" % (inner_path, error)})
             self.connection.badAction(5)
 
     def isReadable(self, site, inner_path, file, pos):


### PR DESCRIPTION
```
commit 941571f71f6c75b1ebcb0c75c6987b76cc47df16 (HEAD -> PR-py3--cryptmsg-base64-type, rf/PR-py3--cryptmsg-base64-type)
Author: redfish <redfish@galactica.pw>
Date:   Sun Mar 31 16:25:26 2019 -0400

    file: set error message before using it
    
    Fixes this exception:
    
    Unhandled exception: [(<class 'UnboundLocalError'>,
    UnboundLocalError("local variable 'err' referenced before assignm>
     Traceback (most recent call last):
       File "src/gevent/greenlet.py", line 766, in gevent._greenlet.Greenlet.run
       File "/opt/zeronet/src/util/RateLimit.py", line 57, in <lambda>
         thread = gevent.spawn_later(time_left, lambda: callQueue(event))  # Call this function later
       File "/opt/zeronet/src/util/RateLimit.py", line 42, in callQueue
         return func(*args, **kwargs)
       File "/opt/zeronet/src/File/FileRequest.py", line 185, in actionUpdate
         self.response({"error": "File invalid: %s" % err})
    UnboundLocalError: local variable 'err' referenced before assignment

commit 65be9f438bc11902c8357bbe86a9a86ac60f3f81
Author: redfish <redfish@galactica.pw>
Date:   Sun Mar 31 14:05:15 2019 -0400

    CryptMessage: pass byte-array type to base64
    
    Fixes this error upon sending a message in ZeroMail:
    WebSocket handleRequest error: TypeError: a bytes-like object is
    required, not 'str' in UiWebsocket.py line 83 > UiWebsocket.py line 269
    > CryptMessage/CryptMessagePlugin.py line 80 >
    CryptMessage/CryptMessagePlugin.py line 80 > base64.py line 58
```