### PR TITLE
OptionalFileList - Added support for filter not_downloaded

### DIFF
--- a/plugins/OptionalManager/UiWebsocketPlugin.py
+++ b/plugins/OptionalManager/UiWebsocketPlugin.py
@@ -132,8 +132,12 @@ class UiWebsocketPlugin(object):
         wheres_raw = []
         if "bigfile" in filter:
             wheres["size >"] = 1024 * 1024 * 10
-        if "downloaded" in filter:
+
+        if "not_downloaded" in filter:
+            wheres["is_downloaded"] = 0
+        elif "downloaded" in filter:
             wheres_raw.append("(is_downloaded = 1 OR is_pinned = 1)")
+
         if "pinned" in filter:
             wheres["is_pinned"] = 1
 


### PR DESCRIPTION
We have **optionalFileList** command and filters: **downloaded**, **bigfile**, **pinned**, **downloaded**. 

Added support to **not_downloaded** filter to get all not downloaded files through API.

This is much better solution then checking **entry.is_downloaded** in loop in JavaScript.

Example:
```
var address='1CiXRY9ATZSoZqBzwMfXEMsKtPRt2aQoF2';

zeroframe.cmd('optionalFileList', {"address":address, "orderby": "inner_path ASC", "filter":"not_downloaded", "limit": 1000}, function(lst) {
	lst.forEach(function(entry) {
		console.log(entry.is_downloaded + ' ' + entry.inner_path);
	});
});
```

To add to queue not downloaded files now we can use

```
var address='1uPLoaDwKzP6MCGoVzw48r4pxawRBdmQc';
zeroframe.cmd('optionalFileList', {"address":address, "orderby": "inner_path ASC", "filter":"not_downloaded", "limit": 1000}, function(lst) {
	lst.forEach(function(entry) {
		console.log(entry.peer + ' "' + entry.inner_path + '" size: ' + entry.size);
		zeroframe.cmd('fileNeed', entry.inner_path + '|all', function(e) {
			console.log(e);
		});
	});
});
```