### PR TITLE
Added support for encrypted connections in Dockerfile - added OpenSSL…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8
 ENV HOME /root
 
 #Install ZeroNet
-RUN apk --no-cache --no-progress add musl-dev gcc python python-dev py2-pip tor \
+RUN apk --no-cache --no-progress add musl-dev gcc python python-dev py2-pip tor openssl \
  && pip install --no-cache-dir gevent msgpack \
  && apk del musl-dev gcc python-dev py2-pip \
  && echo "ControlPort 9051" >> /etc/tor/torrc \


### PR DESCRIPTION
I have added **openssl** library to Dockerfile to enable **tls** encryption.

On screenshot, you can see previous ZeroNet Dockerfile version without OpenSSL (top image) and with installed OpenSSL - bottom

![openssl-tls](https://user-images.githubusercontent.com/655681/55572126-38275480-5707-11e9-855e-cbb0dee3574b.png)
