### PR TITLE
Change default value to 10MB

### DIFF
--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -772,7 +772,7 @@ class SitePlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("Bigfile plugin")
-        group.add_argument('--autodownload_bigfile_size_limit', help='Also download bigfiles smaller than this limit if help distribute option is checked', default=1, metavar="MB", type=int)
+        group.add_argument('--autodownload_bigfile_size_limit', help='Also download bigfiles smaller than this limit if help distribute option is checked', default=10, metavar="MB", type=int)
         group.add_argument('--bigfile_size_limit', help='Maximum size of downloaded big files', default=False, metavar="MB", type=int)
 
         return super(ConfigPlugin, self).createArguments()


### PR DESCRIPTION
Big File is an optional file which is bigger than 10MB, so the default value should be at least 10MB, which means the effect for setting this value to any number that is lower than 10 is the same as the one with 10MB.
When I open this toggle `Download and help distribute all files` in the side bar, all the small optional files (lower than 10MB) will be downloaded no matter the value of `Auto download big file size limit` is 1MB or 10MB. It will give a misunderstanding that why the optional file that is even bigger than 1MB  is also downloaded, when the `..file size limit` value is just 1MB. (Because the value is only valid for big file which is bigger than 10MB). For eliminating misconception, so the default value should be 10MB.