### PR TITLE
Fix double --open_browser

### DIFF
--- a/start.py
+++ b/start.py
@@ -9,7 +9,8 @@ import zeronet
 
 
 def main():
-    sys.argv = [sys.argv[0]]+["--open_browser", "default_browser"]+sys.argv[1:]
+	if "--open_browser" not in sys.argv:
+    	sys.argv = [sys.argv[0]] + ["--open_browser", "default_browser"] + sys.argv[1:]
     zeronet.main()
 
 if __name__ == '__main__':

--- a/start.py
+++ b/start.py
@@ -9,8 +9,8 @@ import zeronet
 
 
 def main():
-	if "--open_browser" not in sys.argv:
-    	sys.argv = [sys.argv[0]] + ["--open_browser", "default_browser"] + sys.argv[1:]
+    if "--open_browser" not in sys.argv:
+        sys.argv = [sys.argv[0]] + ["--open_browser", "default_browser"] + sys.argv[1:]
     zeronet.main()
 
 if __name__ == '__main__':


### PR DESCRIPTION
When you call `start.py`, it calls `zeronet.py` with argument `--open_browser default_browser`. `Config.py` parses `zeronet.conf` and changes this `--open_browser default_browser` to `--open_browser correctbrowser`. 

Pretend you untoggle `Open web browser on ZeroNet startup` in UiConfig.

Then, if you restart ZeroNet (e.g. from UiConfig), ZeroNet calls *the current executable* with *the arguments it was called with*: `start.py --open_browser default_browser`. `start.py` calls `zeronet.py --open_browser default_browser --open_browser default_browser`. Then, `Config.py` reads the correct value (`False`) from `zeronet.conf`, and replaces `--open_browser default_browser` with `--open_browser False`. However, only the first instance is replaced, and you get `--open_browser False --open_browser default_browser`. When this string is parsed, the latter value is used, and the browser is opened (which is not what you expected).