### PR TITLE
[setuptools packaging] remove some  dead code related to openssl, pyelliptic

### DIFF
--- a/zeronet.py
+++ b/zeronet.py
@@ -24,12 +24,6 @@ def main():
         if main.update_after_shutdown:  # Updater
             import gc
             import update
-            # Try cleanup openssl
-            try:
-                if "lib.pyelliptic" in sys.modules:
-                    sys.modules["lib.pyelliptic"].openssl.closeLibrary()
-            except Exception as err:
-                print("Error closing pyelliptic lib", err)
 
             # Close lock file
             sys.modules["main"].lock.close()

--- a/zeronet.py
+++ b/zeronet.py
@@ -26,11 +26,6 @@ def main():
             import update
             # Try cleanup openssl
             try:
-                if "lib.opensslVerify" in sys.modules:
-                    sys.modules["lib.opensslVerify"].opensslVerify.closeLibrary()
-            except Exception as err:
-                print("Error closing opensslVerify lib", err)
-            try:
                 if "lib.pyelliptic" in sys.modules:
                     sys.modules["lib.pyelliptic"].openssl.closeLibrary()
             except Exception as err:


### PR DESCRIPTION
This PR is part of preparatory patches for setuptools (setup.py) packaging (which is ready, but I'm trying to minimize the size of that diff by splitting all independent changes into separate PRs).

*  zeronet: no openssl.closeLibrary in pyelliptic
    Not in pyelliptic  (neither in 1.6.7 nor 2.0.1)

grep closeLibrary shows nothing: do you know what else to check?

 * zeronet: remove ref to opensslVerify
    This module is no longer used. Does not exist in lib/
