### PR TITLE
[setuptools packaging] factor path to testdata, log error

### DIFF
--- a/src/Test/TestSite.py
+++ b/src/Test/TestSite.py
@@ -4,16 +4,17 @@ import os
 import pytest
 from Site import SiteManager
 
+TEST_DATA_PATH = "src/Test/testdata"
 
 @pytest.mark.usefixtures("resetSettings")
 class TestSite:
     def testClone(self, site):
-        assert site.storage.directory == "src/Test/testdata/1TeSTvb4w2PWE81S2rEELgmX2GCCExQGT"
+        assert site.storage.directory == TEST_DATA_PATH + "/1TeSTvb4w2PWE81S2rEELgmX2GCCExQGT"
 
         # Remove old files
-        if os.path.isdir("src/Test/testdata/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL"):
-            shutil.rmtree("src/Test/testdata/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL")
-        assert not os.path.isfile("src/Test/testdata/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL/content.json")
+        if os.path.isdir(TEST_DATA_PATH + "/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL"):
+            shutil.rmtree(TEST_DATA_PATH + "/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL")
+        assert not os.path.isfile(TEST_DATA_PATH + "/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL/content.json")
 
         # Clone 1TeSTvb4w2PWE81S2rEELgmX2GCCExQGT to 15E5rhcAUD69WbiYsYARh4YHJ4sLm2JEyc
         new_site = site.clone(
@@ -61,7 +62,7 @@ class TestSite:
 
         # Delete created files
         new_site.storage.deleteFiles()
-        assert not os.path.isdir("src/Test/testdata/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL")
+        assert not os.path.isdir(TEST_DATA_PATH + "/159EGD5srUsMP97UpcLy8AtKQbQLK2AbbL")
 
         # Delete from site registry
         assert new_site.address in SiteManager.site_manager.sites

--- a/src/Test/conftest.py
+++ b/src/Test/conftest.py
@@ -72,7 +72,8 @@ fmt = logging.Formatter(fmt='+%(relative)ss %(levelname)-8s %(name)s %(message)s
 # Load plugins
 from Plugin import PluginManager
 
-config.data_dir = "src/Test/testdata"  # Use test data for unittests
+TEST_DATA_PATH  = 'src/Test/testdata'
+config.data_dir = TEST_DATA_PATH  # Use test data for unittests
 
 os.chdir(os.path.abspath(os.path.dirname(__file__) + "/../.."))  # Set working dir
 
@@ -85,7 +86,7 @@ config.debug_socket = True  # Use test data for unittests
 config.verbose = True  # Use test data for unittests
 config.tor = "disable"  # Don't start Tor client
 config.trackers = []
-config.data_dir = "src/Test/testdata"  # Use test data for unittests
+config.data_dir = TEST_DATA_PATH  # Use test data for unittests
 config.initLogging()
 
 from Site import Site


### PR DESCRIPTION
This PR is part of preparatory patches for setuptools (setup.py) packaging (which is ready, but I'm trying to minimize the size of that diff by splitting all independent changes into separate PRs).

* test: refer to test data path via variable (refactoring only, no change to functionality)

* UiRequest: log error respones
    
    Useful during development. In some cases, things brake, but no error
    shows up anywhere. Add logging for that case.