### PR TITLE
[setuptools packaging] config: path.expanduser returns py3 strings

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -50,16 +50,16 @@ class Config(object):
             # Running as ZeroNet.app
             if this_file.startswith("/Application") or this_file.startswith("/private") or this_file.startswith(os.path.expanduser("~/Library")):
                 # Runnig from non-writeable directory, put data to Application Support
-                start_dir = os.path.expanduser("~/Library/Application Support/ZeroNet").decode(sys.getfilesystemencoding())
+                start_dir = os.path.expanduser("~/Library/Application Support/ZeroNet")
             else:
                 # Running from writeable directory put data next to .app
-                start_dir = re.sub("/[^/]+/Contents/Resources/core/src/Config.py", "", this_file).decode(sys.getfilesystemencoding())
+                start_dir = re.sub("/[^/]+/Contents/Resources/core/src/Config.py", "", this_file)
         elif this_file.endswith("/core/src/Config.py"):
             # Running as exe or source is at Application Support directory, put var files to outside of core dir
-            start_dir = this_file.replace("/core/src/Config.py", "").decode(sys.getfilesystemencoding())
+            start_dir = this_file.replace("/core/src/Config.py", "")
         elif this_file.endswith("usr/share/zeronet/src/Config.py"):
             # Running from non-writeable location, e.g., AppImage
-            start_dir = os.path.expanduser("~/ZeroNet").decode(sys.getfilesystemencoding())
+            start_dir = os.path.expanduser("~/ZeroNet")
         else:
             start_dir = "."
 


### PR DESCRIPTION
path.expanduser returns py3 strings and this_file is a string, and strings have no decode method.