### PR TITLE
[setuptools packaging] zeronet: bump script interpreter to python3

### DIFF
--- a/start.py
+++ b/start.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 
 # Included modules

--- a/zeronet.py
+++ b/zeronet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
 # Included modules
 import os


### PR DESCRIPTION
This PR is part of preparatory patches for setuptools  (setup.py) packaging (which is ready, but I'm trying to minimize the  size of that diff by splitting all independent changes into separate  PRs).

I assume it is ok to bump the python version in the script now regardless, but this is particularly necessary for setuptools package, because the script will be invoked standalone (not via `python  script`).