### PR TITLE
Get rid of pyelliptic

### DIFF
--- a/plugins/CryptMessage/CryptMessage.py
+++ b/plugins/CryptMessage/CryptMessage.py
@@ -6,13 +6,11 @@ import lib.pybitcointools as btctools
 ecc_cache = {}
 
 
-def eciesEncrypt(data, pubkey, ephemcurve=None, ciphername='aes-256-cbc'):
+def eciesEncrypt(data, pubkey, ciphername='aes-256-cbc'):
     import pyelliptic
     pubkey_openssl = toOpensslPublickey(base64.b64decode(pubkey))
     curve, pubkey_x, pubkey_y, i = pyelliptic.ECC._decode_pubkey(pubkey_openssl)
-    if ephemcurve is None:
-        ephemcurve = curve
-    ephem = pyelliptic.ECC(curve=ephemcurve)
+    ephem = pyelliptic.ECC(curve=curve)
     key = hashlib.sha512(ephem.raw_get_ecdh_key(pubkey_x, pubkey_y)).digest()
     key_e, key_m = key[:32], key[32:]
     pubkey = ephem.get_pubkey()

--- a/plugins/CryptMessage/CryptMessage.py
+++ b/plugins/CryptMessage/CryptMessage.py
@@ -2,56 +2,10 @@ import hashlib
 import base64
 
 import lib.pybitcointools as btctools
-
-ecc_cache = {}
-
-
-def eciesEncrypt(data, pubkey, ciphername='aes-256-cbc'):
-    import pyelliptic
-    pubkey_openssl = toOpensslPublickey(base64.b64decode(pubkey))
-    curve, pubkey_x, pubkey_y, i = pyelliptic.ECC._decode_pubkey(pubkey_openssl)
-    ephem = pyelliptic.ECC(curve=curve)
-    key = hashlib.sha512(ephem.raw_get_ecdh_key(pubkey_x, pubkey_y)).digest()
-    key_e, key_m = key[:32], key[32:]
-    pubkey = ephem.get_pubkey()
-    iv = pyelliptic.OpenSSL.rand(pyelliptic.OpenSSL.get_cipher(ciphername).get_blocksize())
-    ctx = pyelliptic.Cipher(key_e, iv, 1, ciphername)
-    ciphertext = iv + pubkey + ctx.ciphering(data)
-    mac = pyelliptic.hmac_sha256(key_m, ciphertext)
-    return key_e, ciphertext + mac
-
-def eciesDecrypt(encrypted_data, privatekey):
-    ecc_key = getEcc(privatekey)
-    return ecc_key.decrypt(base64.b64decode(encrypted_data))
+from lib.ecies import eciesEncrypt, eciesDecrypt
 
 def split(encrypted):
     iv = encrypted[0:16]
     ciphertext = encrypted[16 + 70:-32]
 
     return iv, ciphertext
-
-
-def getEcc(privatekey=None):
-    import pyelliptic
-    global ecc_cache
-    if privatekey not in ecc_cache:
-        if privatekey:
-            publickey_bin = btctools.encode_pubkey(btctools.privtopub(privatekey), "bin")
-            publickey_openssl = toOpensslPublickey(publickey_bin)
-            privatekey_openssl = toOpensslPrivatekey(privatekey)
-            ecc_cache[privatekey] = pyelliptic.ECC(curve='secp256k1', privkey=privatekey_openssl, pubkey=publickey_openssl)
-        else:
-            ecc_cache[None] = pyelliptic.ECC()
-    return ecc_cache[privatekey]
-
-
-def toOpensslPrivatekey(privatekey):
-    privatekey_bin = btctools.encode_privkey(privatekey, "bin")
-    return b'\x02\xca\x00\x20' + privatekey_bin
-
-
-def toOpensslPublickey(publickey):
-    publickey_bin = btctools.encode_pubkey(publickey, "bin")
-    publickey_bin = publickey_bin[1:]
-    publickey_openssl = b'\x02\xca\x00 ' + publickey_bin[:32] + b'\x00 ' + publickey_bin[32:]
-    return publickey_openssl

--- a/plugins/CryptMessage/CryptMessagePlugin.py
+++ b/plugins/CryptMessage/CryptMessagePlugin.py
@@ -10,10 +10,6 @@ from . import CryptMessage
 
 @PluginManager.registerTo("UiWebsocket")
 class UiWebsocketPlugin(object):
-    def eciesDecrypt(self, encrypted, privatekey):
-        back = CryptMessage.getEcc(privatekey).decrypt(encrypted)
-        return back.decode("utf8")
-
     # - Actions -
 
     # Returns user's public key unique to site

--- a/plugins/CryptMessage/CryptMessagePlugin.py
+++ b/plugins/CryptMessage/CryptMessagePlugin.py
@@ -45,7 +45,7 @@ class UiWebsocketPlugin(object):
         texts = []  # Decoded texts
         for encrypted_text in encrypted_texts:
             try:
-                text = CryptMessage.eciesDecrypt(encrypted_text, privatekey).decode("utf8")
+                text = CryptMessage.eciesDecrypt(base64.b64decode(encrypted_text), privatekey).decode("utf8")
                 texts.append(text)
             except Exception as err:
                 texts.append(None)

--- a/plugins/CryptMessage/Test/TestCrypt.py
+++ b/plugins/CryptMessage/Test/TestCrypt.py
@@ -18,13 +18,11 @@ class TestCrypt:
         assert len(aes_key) == 32
         # assert len(encrypted) == 134 + int(len(text) / 16) * 16  # Not always true
 
-        ecc = CryptMessage.getEcc(self.privatekey)
-        assert ecc.decrypt(encrypted) == text_repeated
+        assert CryptMessage.eciesDecrypt(encrypted, self.privatekey) == text_repeated
 
     def testDecryptEcies(self, user):
         encrypted = base64.b64decode(self.ecies_encrypted_text)
-        ecc = CryptMessage.getEcc(self.privatekey)
-        assert ecc.decrypt(encrypted) == b"hello"
+        assert CryptMessage.eciesDecrypt(encrypted, self.privatekey) == b"hello"
 
     def testPublickey(self, ui_websocket):
         pub = ui_websocket.testAction("UserPublickey", 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ gevent>=1.1.0
 msgpack>=0.4.4
 base58
 merkletools
-pyelliptic==1.5.6
 rsa
 PySocks
 pyasn1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ bencode.py
 coincurve
 python-bitcoinlib
 maxminddb
+pycryptodome

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ bencode.py
 coincurve
 python-bitcoinlib
 maxminddb
-pycryptodome
+pycryptodomex

--- a/src/lib/ecies/__init__.py
+++ b/src/lib/ecies/__init__.py
@@ -6,11 +6,9 @@ import base64
 import os
 import hmac
 
-from . import elliptic, pack
+from . import pack
+from .ecdh import ecdh
 
-
-def ecdh(privatekey, publickey):
-    return elliptic.scalar_mult(privatekey, publickey)[0].to_bytes(32, byteorder="big")
 def derive(privatekey, publickey):
     return sha512(ecdh(privatekey, publickey)).digest()
 
@@ -24,11 +22,10 @@ def eciesDecrypt(enc, privatekey):
     key = derive(privatekey, data["publickey"])
     key_e, key_m = key[:32], key[32:]
 
-    cipher = AES.new(key_e, AES.MODE_CBC, data["iv"])
-
     mac = hmac.new(key_m, enc[:-32], digestmod="sha256").digest()
     assert mac == data["mac"]
 
+    cipher = AES.new(key_e, AES.MODE_CBC, data["iv"])
     return unpad(cipher.decrypt(data["ciphertext"]), AES.block_size)
 
 

--- a/src/lib/ecies/__init__.py
+++ b/src/lib/ecies/__init__.py
@@ -1,0 +1,62 @@
+# TODO: get rid of pyelliptic
+
+
+from lib import pybitcointools as btctools
+from hashlib import sha512
+from Cryptodome.Cipher import AES  # pycryptodome
+from Cryptodome.Util.Padding import pad, unpad
+import base64
+import pyelliptic
+import os
+
+from . import elliptic, pack
+
+
+def ecdh(privatekey, publickey):
+    return elliptic.scalar_mult(privatekey, publickey)[0].to_bytes(32, byteorder="big")
+def derive(privatekey, publickey):
+    return sha512(ecdh(privatekey, publickey)).digest()
+
+
+def eciesDecrypt(enc, privatekey):
+    data = pack.parseEciesData(base64.b64decode(enc))
+
+    privatekey = btctools.decode_privkey(privatekey, "wif_compressed")
+
+    key = derive(privatekey, data["publickey"])
+    key_e, key_m = key[:32], key[32:]
+
+    cipher = AES.new(key_e, AES.MODE_CBC, data["iv"])
+
+    mac = pyelliptic.hmac_sha256(key_m, data["ciphertext"])
+    assert mac == data["mac"]
+
+    return unpad(cipher.decrypt(data["ciphertext"]), AES.block_size)
+
+
+
+def eciesEncrypt(data, publickey):
+    publickey = btctools.decode_pubkey(base64.b64decode(publickey), "bin_compressed")
+
+    my_privatekey = int.from_bytes(os.urandom(32), byteorder="big")
+    my_publickey = btctools.privtopub(my_privatekey)
+
+    key = derive(my_privatekey, publickey)
+    key_e, key_m = key[:32], key[32:]
+
+    iv = os.urandom(16)
+
+    cipher = AES.new(key_e, AES.MODE_CBC, iv)
+    ciphertext = cipher.encrypt(pad(data, AES.block_size))
+
+    mac = pyelliptic.hmac_sha256(key_m, ciphertext)
+
+    data = {
+        "iv": iv,
+        "curve": 714,
+        "publickey": my_publickey,
+        "ciphertext": ciphertext,
+        "mac": mac
+    }
+
+    return base64.b64encode(key_e), base64.b64encode(pack.encodeEciesData(data))

--- a/src/lib/ecies/__init__.py
+++ b/src/lib/ecies/__init__.py
@@ -14,7 +14,6 @@ def derive(privatekey, publickey):
 
 
 def eciesDecrypt(enc, privatekey):
-    enc = base64.b64decode(enc)
     data = pack.parseEciesData(enc)
 
     privatekey = btctools.decode_privkey(privatekey, "wif_compressed")
@@ -55,4 +54,4 @@ def eciesEncrypt(data, publickey):
     # Add correct MAC
     data["mac"] = hmac.new(key_m, pack.encodeEciesData(data)[:-32], digestmod="sha256").digest()
 
-    return base64.b64encode(key_e), base64.b64encode(pack.encodeEciesData(data))
+    return key_e, pack.encodeEciesData(data)

--- a/src/lib/ecies/ecdh.py
+++ b/src/lib/ecies/ecdh.py
@@ -66,9 +66,9 @@ def ecdh(privatekey, publickey):
         if (OpenSSL.EC_KEY_set_private_key(own_key, own_priv_key)) == 0:
             raise Exception("[OpenSSL] EC_KEY_set_private_key FAIL ...")
 
-        OpenSSL.ECDH_set_method(own_key, OpenSSL.ECDH_OpenSSL())
         ecdh_keylen = OpenSSL.ECDH_compute_key(
-            ecdh_keybuffer, 32, other_pub_key, own_key, 0)
+            ecdh_keybuffer, 32, other_pub_key, own_key, 0
+        )
 
         if ecdh_keylen != 32:
             raise Exception("[OpenSSL] ECDH keylen FAIL ...")

--- a/src/lib/ecies/ecdh.py
+++ b/src/lib/ecies/ecdh.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2014 Yann GUIBET <yannguibet@gmail.com>.
+# All rights reserved.
+#
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from .openssl import OpenSSL
+
+
+def ecdh(privatekey, publickey):
+    privatekey = privatekey.to_bytes(32, byteorder="big")
+    publickey = tuple(map(lambda k: k.to_bytes(32, byteorder="big"), publickey))
+
+    try:
+        ecdh_keybuffer = OpenSSL.malloc(0, 32)
+
+        other_key = OpenSSL.EC_KEY_new_by_curve_name(714)
+        if other_key == 0:
+            raise Exception("[OpenSSL] EC_KEY_new_by_curve_name FAIL ...")
+
+        other_pub_key_x = OpenSSL.BN_bin2bn(publickey[0], 32, 0)
+        other_pub_key_y = OpenSSL.BN_bin2bn(publickey[1], 32, 0)
+
+        other_group = OpenSSL.EC_KEY_get0_group(other_key)
+        other_pub_key = OpenSSL.EC_POINT_new(other_group)
+
+        if (OpenSSL.EC_POINT_set_affine_coordinates_GFp(other_group,
+                                                        other_pub_key,
+                                                        other_pub_key_x,
+                                                        other_pub_key_y,
+                                                        0)) == 0:
+            raise Exception(
+                "[OpenSSL] EC_POINT_set_affine_coordinates_GFp FAIL ...")
+        if (OpenSSL.EC_KEY_set_public_key(other_key, other_pub_key)) == 0:
+            raise Exception("[OpenSSL] EC_KEY_set_public_key FAIL ...")
+        if (OpenSSL.EC_KEY_check_key(other_key)) == 0:
+            raise Exception("[OpenSSL] EC_KEY_check_key FAIL ...")
+
+        own_key = OpenSSL.EC_KEY_new_by_curve_name(714)
+        if own_key == 0:
+            raise Exception("[OpenSSL] EC_KEY_new_by_curve_name FAIL ...")
+        own_priv_key = OpenSSL.BN_bin2bn(privatekey, 32, 0)
+
+        if (OpenSSL.EC_KEY_set_private_key(own_key, own_priv_key)) == 0:
+            raise Exception("[OpenSSL] EC_KEY_set_private_key FAIL ...")
+
+        OpenSSL.ECDH_set_method(own_key, OpenSSL.ECDH_OpenSSL())
+        ecdh_keylen = OpenSSL.ECDH_compute_key(
+            ecdh_keybuffer, 32, other_pub_key, own_key, 0)
+
+        if ecdh_keylen != 32:
+            raise Exception("[OpenSSL] ECDH keylen FAIL ...")
+
+        return ecdh_keybuffer.raw
+
+    finally:
+        OpenSSL.EC_KEY_free(other_key)
+        OpenSSL.BN_free(other_pub_key_x)
+        OpenSSL.BN_free(other_pub_key_y)
+        OpenSSL.EC_POINT_free(other_pub_key)
+        OpenSSL.EC_KEY_free(own_key)
+        OpenSSL.BN_free(own_priv_key)

--- a/src/lib/ecies/elliptic.py
+++ b/src/lib/ecies/elliptic.py
@@ -1,0 +1,147 @@
+import collections
+
+
+EllipticCurve = collections.namedtuple("EllipticCurve", "name p a b g n h")
+
+curve = EllipticCurve(
+    "secp256k1",
+    # Field characteristic.
+    p=0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f,
+    # Curve coefficients.
+    a=0,
+    b=7,
+    # Base point.
+    g=(0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798,
+       0x483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8),
+    # Subgroup order.
+    n=0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141,
+    # Subgroup cofactor.
+    h=1,
+)
+
+
+# Modular arithmetic ##########################################################
+
+def inverse_mod(k, p):
+    """Returns the inverse of k modulo p.
+    This function returns the only integer x such that (x * k) % p == 1.
+    k must be non-zero and p must be a prime.
+    """
+    if k == 0:
+        raise ZeroDivisionError("Division by zero")
+
+    if k < 0:
+        # k ** -1 = p - (-k) ** -1  (mod p)
+        return p - inverse_mod(-k, p)
+
+    # Extended Euclidean algorithm.
+    s, old_s = 0, 1
+    t, old_t = 1, 0
+    r, old_r = p, k
+
+    while r != 0:
+        quotient = old_r // r
+        old_r, r = r, old_r - quotient * r
+        old_s, s = s, old_s - quotient * s
+        old_t, t = t, old_t - quotient * t
+
+    gcd, x, y = old_r, old_s, old_t
+
+    assert gcd == 1
+    assert (k * x) % p == 1
+
+    return x % p
+
+
+# Functions that work on curve points #########################################
+
+def is_on_curve(point):
+    """Returns True if the given point lies on the elliptic curve."""
+    if point is None:
+        # None represents the point at infinity.
+        return True
+
+    x, y = point
+
+    return (y * y - x * x * x - curve.a * x - curve.b) % curve.p == 0
+
+
+def point_neg(point):
+    """Returns -point."""
+    assert is_on_curve(point)
+
+    if point is None:
+        # -0 = 0
+        return None
+
+    x, y = point
+    result = (x, -y % curve.p)
+
+    assert is_on_curve(result)
+
+    return result
+
+
+def point_add(point1, point2):
+    """Returns the result of point1 + point2 according to the group law."""
+    assert is_on_curve(point1)
+    assert is_on_curve(point2)
+
+    if point1 is None:
+        # 0 + point2 = point2
+        return point2
+    if point2 is None:
+        # point1 + 0 = point1
+        return point1
+
+    x1, y1 = point1
+    x2, y2 = point2
+
+    if x1 == x2 and y1 != y2:
+        # point1 + (-point1) = 0
+        return None
+
+    if x1 == x2:
+        # This is the case point1 == point2.
+        m = (3 * x1 * x1 + curve.a) * inverse_mod(2 * y1, curve.p)
+    else:
+        # This is the case point1 != point2.
+        m = (y1 - y2) * inverse_mod(x1 - x2, curve.p)
+
+    x3 = m * m - x1 - x2
+    y3 = y1 + m * (x3 - x1)
+    result = (x3 % curve.p,
+              -y3 % curve.p)
+
+    assert is_on_curve(result)
+
+    return result
+
+
+def scalar_mult(k, point):
+    """Returns k * point computed using the double and point_add algorithm."""
+    assert is_on_curve(point)
+
+    if k % curve.n == 0 or point is None:
+        return None
+
+    if k < 0:
+        # k * point = -k * (-point)
+        return scalar_mult(-k, point_neg(point))
+
+    result = None
+    addend = point
+
+    while k:
+        if k & 1:
+            # Add.
+            result = point_add(result, addend)
+
+        # Double.
+        addend = point_add(addend, addend)
+
+        k >>= 1
+
+    assert is_on_curve(result)
+
+    return result

--- a/src/lib/ecies/openssl.py
+++ b/src/lib/ecies/openssl.py
@@ -1,0 +1,501 @@
+# Copyright (c) 2014 Yann GUIBET <yannguibet@gmail.com>.
+# All rights reserved.
+#
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in
+#     the documentation and/or other materials provided with the
+#     distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+# BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+# IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import ctypes
+import ctypes.util
+
+OpenSSL = None
+
+
+class CipherName:
+    def __init__(self, name, pointer, blocksize):
+        self._name = name
+        self._pointer = pointer
+        self._blocksize = blocksize
+
+    def __str__(self):
+        return ("Cipher : %s | Blocksize : %s | Fonction pointer : %s" %
+                (self._name, str(self._blocksize), str(self._pointer)))
+
+    def get_pointer(self):
+        return self._pointer()
+
+    def get_name(self):
+        return self._name
+
+    def get_blocksize(self):
+        return self._blocksize
+
+
+class _OpenSSL:
+    """
+    Wrapper for OpenSSL using ctypes
+    """
+    def __init__(self, library):
+        """
+        Build the wrapper
+        """
+        self._lib = ctypes.CDLL(library)
+
+        self.pointer = ctypes.pointer
+        self.c_int = ctypes.c_int
+        self.byref = ctypes.byref
+        self.create_string_buffer = ctypes.create_string_buffer
+
+        self.BN_new = self._lib.BN_new
+        self.BN_new.restype = ctypes.c_void_p
+        self.BN_new.argtypes = []
+
+        self.BN_free = self._lib.BN_free
+        self.BN_free.restype = None
+        self.BN_free.argtypes = [ctypes.c_void_p]
+
+        self.BN_num_bits = self._lib.BN_num_bits
+        self.BN_num_bits.restype = ctypes.c_int
+        self.BN_num_bits.argtypes = [ctypes.c_void_p]
+
+        self.BN_bn2bin = self._lib.BN_bn2bin
+        self.BN_bn2bin.restype = ctypes.c_int
+        self.BN_bn2bin.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        self.BN_bin2bn = self._lib.BN_bin2bn
+        self.BN_bin2bn.restype = ctypes.c_void_p
+        self.BN_bin2bn.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                   ctypes.c_void_p]
+
+        self.EC_KEY_free = self._lib.EC_KEY_free
+        self.EC_KEY_free.restype = None
+        self.EC_KEY_free.argtypes = [ctypes.c_void_p]
+
+        self.EC_KEY_new_by_curve_name = self._lib.EC_KEY_new_by_curve_name
+        self.EC_KEY_new_by_curve_name.restype = ctypes.c_void_p
+        self.EC_KEY_new_by_curve_name.argtypes = [ctypes.c_int]
+
+        self.EC_KEY_generate_key = self._lib.EC_KEY_generate_key
+        self.EC_KEY_generate_key.restype = ctypes.c_int
+        self.EC_KEY_generate_key.argtypes = [ctypes.c_void_p]
+
+        self.EC_KEY_check_key = self._lib.EC_KEY_check_key
+        self.EC_KEY_check_key.restype = ctypes.c_int
+        self.EC_KEY_check_key.argtypes = [ctypes.c_void_p]
+
+        self.EC_KEY_get0_private_key = self._lib.EC_KEY_get0_private_key
+        self.EC_KEY_get0_private_key.restype = ctypes.c_void_p
+        self.EC_KEY_get0_private_key.argtypes = [ctypes.c_void_p]
+
+        self.EC_KEY_get0_public_key = self._lib.EC_KEY_get0_public_key
+        self.EC_KEY_get0_public_key.restype = ctypes.c_void_p
+        self.EC_KEY_get0_public_key.argtypes = [ctypes.c_void_p]
+
+        self.EC_KEY_get0_group = self._lib.EC_KEY_get0_group
+        self.EC_KEY_get0_group.restype = ctypes.c_void_p
+        self.EC_KEY_get0_group.argtypes = [ctypes.c_void_p]
+
+        self.EC_POINT_get_affine_coordinates_GFp = self._lib.EC_POINT_get_affine_coordinates_GFp
+        self.EC_POINT_get_affine_coordinates_GFp.restype = ctypes.c_int
+        self.EC_POINT_get_affine_coordinates_GFp.argtypes = 5 * [ctypes.c_void_p]
+
+        self.EC_KEY_set_private_key = self._lib.EC_KEY_set_private_key
+        self.EC_KEY_set_private_key.restype = ctypes.c_int
+        self.EC_KEY_set_private_key.argtypes = [ctypes.c_void_p,
+                                                ctypes.c_void_p]
+
+        self.EC_KEY_set_public_key = self._lib.EC_KEY_set_public_key
+        self.EC_KEY_set_public_key.restype = ctypes.c_int
+        self.EC_KEY_set_public_key.argtypes = [ctypes.c_void_p,
+                                               ctypes.c_void_p]
+
+        self.EC_KEY_set_group = self._lib.EC_KEY_set_group
+        self.EC_KEY_set_group.restype = ctypes.c_int
+        self.EC_KEY_set_group.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        self.EC_POINT_set_affine_coordinates_GFp = self._lib.EC_POINT_set_affine_coordinates_GFp
+        self.EC_POINT_set_affine_coordinates_GFp.restype = ctypes.c_int
+        self.EC_POINT_set_affine_coordinates_GFp.argtypes = 5 * [ctypes.c_void_p]
+
+        self.EC_POINT_new = self._lib.EC_POINT_new
+        self.EC_POINT_new.restype = ctypes.c_void_p
+        self.EC_POINT_new.argtypes = [ctypes.c_void_p]
+
+        self.EC_POINT_free = self._lib.EC_POINT_free
+        self.EC_POINT_free.restype = None
+        self.EC_POINT_free.argtypes = [ctypes.c_void_p]
+
+        self.BN_CTX_free = self._lib.BN_CTX_free
+        self.BN_CTX_free.restype = None
+        self.BN_CTX_free.argtypes = [ctypes.c_void_p]
+
+        self.EC_POINT_mul = self._lib.EC_POINT_mul
+        self.EC_POINT_mul.restype = ctypes.c_int
+        self.EC_POINT_mul.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
+                                      ctypes.c_void_p, ctypes.c_void_p,
+                                      ctypes.c_void_p, ctypes.c_void_p]
+
+        self.EC_KEY_set_private_key = self._lib.EC_KEY_set_private_key
+        self.EC_KEY_set_private_key.restype = ctypes.c_int
+        self.EC_KEY_set_private_key.argtypes = [ctypes.c_void_p,
+                                                ctypes.c_void_p]
+
+        self.ECDH_OpenSSL = self._lib.ECDH_OpenSSL
+        self._lib.ECDH_OpenSSL.restype = ctypes.c_void_p
+        self._lib.ECDH_OpenSSL.argtypes = []
+
+        self.BN_CTX_new = self._lib.BN_CTX_new
+        self._lib.BN_CTX_new.restype = ctypes.c_void_p
+        self._lib.BN_CTX_new.argtypes = []
+
+        self.ECDH_set_method = self._lib.ECDH_set_method
+        self._lib.ECDH_set_method.restype = ctypes.c_int
+        self._lib.ECDH_set_method.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        self.ECDH_compute_key = self._lib.ECDH_compute_key
+        self.ECDH_compute_key.restype = ctypes.c_int
+        self.ECDH_compute_key.argtypes = [ctypes.c_void_p,
+                                          ctypes.c_int,
+                                          ctypes.c_void_p,
+                                          ctypes.c_void_p]
+
+        self.EVP_CipherInit_ex = self._lib.EVP_CipherInit_ex
+        self.EVP_CipherInit_ex.restype = ctypes.c_int
+        self.EVP_CipherInit_ex.argtypes = [ctypes.c_void_p,
+                                           ctypes.c_void_p, ctypes.c_void_p]
+
+        self.EVP_CIPHER_CTX_new = self._lib.EVP_CIPHER_CTX_new
+        self.EVP_CIPHER_CTX_new.restype = ctypes.c_void_p
+        self.EVP_CIPHER_CTX_new.argtypes = []
+
+        # Cipher
+        self.EVP_aes_128_cfb128 = self._lib.EVP_aes_128_cfb128
+        self.EVP_aes_128_cfb128.restype = ctypes.c_void_p
+        self.EVP_aes_128_cfb128.argtypes = []
+
+        self.EVP_aes_256_cfb128 = self._lib.EVP_aes_256_cfb128
+        self.EVP_aes_256_cfb128.restype = ctypes.c_void_p
+        self.EVP_aes_256_cfb128.argtypes = []
+
+        self.EVP_aes_128_cbc = self._lib.EVP_aes_128_cbc
+        self.EVP_aes_128_cbc.restype = ctypes.c_void_p
+        self.EVP_aes_128_cbc.argtypes = []
+
+        self.EVP_aes_256_cbc = self._lib.EVP_aes_256_cbc
+        self.EVP_aes_256_cbc.restype = ctypes.c_void_p
+        self.EVP_aes_256_cbc.argtypes = []
+
+        try:
+            self.EVP_aes_128_ctr = self._lib.EVP_aes_128_ctr
+        except AttributeError:
+            pass
+        else:
+            self.EVP_aes_128_ctr.restype = ctypes.c_void_p
+            self.EVP_aes_128_ctr.argtypes = []
+
+        try:
+            self.EVP_aes_256_ctr = self._lib.EVP_aes_256_ctr
+        except AttributeError:
+            pass
+        else:
+            self.EVP_aes_256_ctr.restype = ctypes.c_void_p
+            self.EVP_aes_256_ctr.argtypes = []
+
+        self.EVP_aes_128_ofb = self._lib.EVP_aes_128_ofb
+        self.EVP_aes_128_ofb.restype = ctypes.c_void_p
+        self.EVP_aes_128_ofb.argtypes = []
+
+        self.EVP_aes_256_ofb = self._lib.EVP_aes_256_ofb
+        self.EVP_aes_256_ofb.restype = ctypes.c_void_p
+        self.EVP_aes_256_ofb.argtypes = []
+
+        self.EVP_bf_cbc = self._lib.EVP_bf_cbc
+        self.EVP_bf_cbc.restype = ctypes.c_void_p
+        self.EVP_bf_cbc.argtypes = []
+
+        self.EVP_bf_cfb64 = self._lib.EVP_bf_cfb64
+        self.EVP_bf_cfb64.restype = ctypes.c_void_p
+        self.EVP_bf_cfb64.argtypes = []
+
+        self.EVP_rc4 = self._lib.EVP_rc4
+        self.EVP_rc4.restype = ctypes.c_void_p
+        self.EVP_rc4.argtypes = []
+
+        self.EVP_CIPHER_CTX_cleanup = self._lib.EVP_CIPHER_CTX_cleanup
+        self.EVP_CIPHER_CTX_cleanup.restype = ctypes.c_int
+        self.EVP_CIPHER_CTX_cleanup.argtypes = [ctypes.c_void_p]
+
+        self.EVP_CIPHER_CTX_free = self._lib.EVP_CIPHER_CTX_free
+        self.EVP_CIPHER_CTX_free.restype = None
+        self.EVP_CIPHER_CTX_free.argtypes = [ctypes.c_void_p]
+
+        self.EVP_CipherUpdate = self._lib.EVP_CipherUpdate
+        self.EVP_CipherUpdate.restype = ctypes.c_int
+        self.EVP_CipherUpdate.argtypes = [ctypes.c_void_p,
+                                          ctypes.c_void_p,
+                                          ctypes.c_void_p,
+                                          ctypes.c_void_p,
+                                          ctypes.c_int]
+
+        self.EVP_CipherFinal_ex = self._lib.EVP_CipherFinal_ex
+        self.EVP_CipherFinal_ex.restype = ctypes.c_int
+        self.EVP_CipherFinal_ex.argtypes = 3 * [ctypes.c_void_p]
+
+        self.EVP_DigestInit = self._lib.EVP_DigestInit
+        self.EVP_DigestInit.restype = ctypes.c_int
+        self._lib.EVP_DigestInit.argtypes = 2 * [ctypes.c_void_p]
+
+        self.EVP_DigestUpdate = self._lib.EVP_DigestUpdate
+        self.EVP_DigestUpdate.restype = ctypes.c_int
+        self.EVP_DigestUpdate.argtypes = [ctypes.c_void_p,
+                                          ctypes.c_void_p,
+                                          ctypes.c_int]
+
+        self.EVP_DigestFinal = self._lib.EVP_DigestFinal
+        self.EVP_DigestFinal.restype = ctypes.c_int
+        self.EVP_DigestFinal.argtypes = [ctypes.c_void_p,
+                                         ctypes.c_void_p, ctypes.c_void_p]
+
+        self.EVP_ecdsa = self._lib.EVP_ecdsa
+        self._lib.EVP_ecdsa.restype = ctypes.c_void_p
+        self._lib.EVP_ecdsa.argtypes = []
+
+        self.ECDSA_sign = self._lib.ECDSA_sign
+        self.ECDSA_sign.restype = ctypes.c_int
+        self.ECDSA_sign.argtypes = [ctypes.c_int,
+                                    ctypes.c_void_p,
+                                    ctypes.c_int,
+                                    ctypes.c_void_p,
+                                    ctypes.c_void_p,
+                                    ctypes.c_void_p]
+
+        self.ECDSA_verify = self._lib.ECDSA_verify
+        self.ECDSA_verify.restype = ctypes.c_int
+        self.ECDSA_verify.argtypes = [ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p,
+                                      ctypes.c_int,
+                                      ctypes.c_void_p]
+
+        self.EVP_MD_CTX_create = self._lib.EVP_MD_CTX_create
+        self.EVP_MD_CTX_create.restype = ctypes.c_void_p
+        self.EVP_MD_CTX_create.argtypes = []
+
+        self.EVP_MD_CTX_init = self._lib.EVP_MD_CTX_init
+        self.EVP_MD_CTX_init.restype = None
+        self.EVP_MD_CTX_init.argtypes = [ctypes.c_void_p]
+
+        self.EVP_MD_CTX_destroy = self._lib.EVP_MD_CTX_destroy
+        self.EVP_MD_CTX_destroy.restype = None
+        self.EVP_MD_CTX_destroy.argtypes = [ctypes.c_void_p]
+
+        self.RAND_bytes = self._lib.RAND_bytes
+        self.RAND_bytes.restype = ctypes.c_int
+        self.RAND_bytes.argtypes = [ctypes.c_void_p, ctypes.c_int]
+
+        self.EVP_sha256 = self._lib.EVP_sha256
+        self.EVP_sha256.restype = ctypes.c_void_p
+        self.EVP_sha256.argtypes = []
+
+        self.i2o_ECPublicKey = self._lib.i2o_ECPublicKey
+        self.i2o_ECPublicKey.restype = ctypes.c_int
+        self.i2o_ECPublicKey.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+        self.EVP_sha512 = self._lib.EVP_sha512
+        self.EVP_sha512.restype = ctypes.c_void_p
+        self.EVP_sha512.argtypes = []
+
+        self.HMAC = self._lib.HMAC
+        self.HMAC.restype = ctypes.c_void_p
+        self.HMAC.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int,
+                              ctypes.c_void_p, ctypes.c_int,
+                              ctypes.c_void_p, ctypes.c_void_p]
+
+        try:
+            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
+        except:
+            # The above is not compatible with all versions of OSX.
+            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC_SHA1
+        self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
+        self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                           ctypes.c_void_p, ctypes.c_int,
+                                           ctypes.c_int, ctypes.c_void_p,
+                                           ctypes.c_int, ctypes.c_void_p]
+
+        self._set_ciphers()
+        self._set_curves()
+
+    def _set_ciphers(self):
+        self.cipher_algo = {
+            'aes-128-cbc': CipherName('aes-128-cbc',
+                                      self.EVP_aes_128_cbc,
+                                      16),
+            'aes-256-cbc': CipherName('aes-256-cbc',
+                                      self.EVP_aes_256_cbc,
+                                      16),
+            'aes-128-cfb': CipherName('aes-128-cfb',
+                                      self.EVP_aes_128_cfb128,
+                                      16),
+            'aes-256-cfb': CipherName('aes-256-cfb',
+                                      self.EVP_aes_256_cfb128,
+                                      16),
+            'aes-128-ofb': CipherName('aes-128-ofb',
+                                      self._lib.EVP_aes_128_ofb,
+                                      16),
+            'aes-256-ofb': CipherName('aes-256-ofb',
+                                      self._lib.EVP_aes_256_ofb,
+                                      16),
+            # 'aes-128-ctr': CipherName('aes-128-ctr',
+            #                           self._lib.EVP_aes_128_ctr,
+            #                           16),
+            # 'aes-256-ctr': CipherName('aes-256-ctr',
+            #                           self._lib.EVP_aes_256_ctr,
+            #                           16),
+            'bf-cfb': CipherName('bf-cfb',
+                                 self.EVP_bf_cfb64,
+                                 8),
+            'bf-cbc': CipherName('bf-cbc',
+                                 self.EVP_bf_cbc,
+                                 8),
+            'rc4': CipherName('rc4',
+                              self.EVP_rc4,
+                              # 128 is the initialisation size not block size
+                              128),
+        }
+
+        if hasattr(self, 'EVP_aes_128_ctr'):
+            self.cipher_algo['aes-128-ctr'] = CipherName(
+                'aes-128-ctr',
+                self._lib.EVP_aes_128_ctr,
+                16
+            )
+        if hasattr(self, 'EVP_aes_256_ctr'):
+            self.cipher_algo['aes-256-ctr'] = CipherName(
+                'aes-256-ctr',
+                self._lib.EVP_aes_256_ctr,
+                16
+            )
+
+    def _set_curves(self):
+        self.curves = {
+            'secp112r1': 704,
+            'secp112r2': 705,
+            'secp128r1': 706,
+            'secp128r2': 707,
+            'secp160k1': 708,
+            'secp160r1': 709,
+            'secp160r2': 710,
+            'secp192k1': 711,
+            'secp224k1': 712,
+            'secp224r1': 713,
+            'secp256k1': 714,
+            'secp384r1': 715,
+            'secp521r1': 716,
+            'sect113r1': 717,
+            'sect113r2': 718,
+            'sect131r1': 719,
+            'sect131r2': 720,
+            'sect163k1': 721,
+            'sect163r1': 722,
+            'sect163r2': 723,
+            'sect193r1': 724,
+            'sect193r2': 725,
+            'sect233k1': 726,
+            'sect233r1': 727,
+            'sect239k1': 728,
+            'sect283k1': 729,
+            'sect283r1': 730,
+            'sect409k1': 731,
+            'sect409r1': 732,
+            'sect571k1': 733,
+            'sect571r1': 734,
+            'prime256v1': 415,
+        }
+
+    def BN_num_bytes(self, x):
+        """
+        returns the length of a BN (OpenSSl API)
+        """
+        return int((self.BN_num_bits(x) + 7) / 8)
+
+    def get_cipher(self, name):
+        """
+        returns the OpenSSL cipher instance
+        """
+        if name not in self.cipher_algo:
+            raise Exception("Unknown cipher")
+        return self.cipher_algo[name]
+
+    def get_curve(self, name):
+        """
+        returns the id of a elliptic curve
+        """
+        if name not in self.curves:
+            raise Exception("Unknown curve")
+        return self.curves[name]
+
+    def get_curve_by_id(self, id):
+        """
+        returns the name of a elliptic curve with his id
+        """
+        res = None
+        for i in self.curves:
+            if self.curves[i] == id:
+                res = i
+                break
+        if res is None:
+            raise Exception("Unknown curve")
+        return res
+
+    def rand(self, size):
+        """
+        OpenSSL random function
+        """
+        buffer = self.malloc(0, size)
+        if self.RAND_bytes(buffer, size) != 1:
+            raise RuntimeError("OpenSSL RAND_bytes failed")
+        return buffer.raw
+
+    def malloc(self, data, size):
+        """
+        returns a create_string_buffer (ctypes)
+        """
+        buffer = None
+        if data != 0:
+            if sys.version_info.major == 3 and isinstance(data, type('')):
+                data = data.encode()
+            buffer = self.create_string_buffer(data, size)
+        else:
+            buffer = self.create_string_buffer(size)
+        return buffer
+
+libname = ctypes.util.find_library('crypto')
+if libname is None:
+    # For Windows ...
+    libname = ctypes.util.find_library('libeay32.dll')
+if libname is None:
+    raise Exception("Couldn't load OpenSSL lib ...")
+OpenSSL = _OpenSSL(libname)

--- a/src/lib/ecies/openssl.py
+++ b/src/lib/ecies/openssl.py
@@ -100,14 +100,6 @@ class _OpenSSL:
         self.EC_KEY_set_private_key.argtypes = [ctypes.c_void_p,
                                                 ctypes.c_void_p]
 
-        self.ECDH_OpenSSL = self._lib.ECDH_OpenSSL
-        self._lib.ECDH_OpenSSL.restype = ctypes.c_void_p
-        self._lib.ECDH_OpenSSL.argtypes = []
-
-        self.ECDH_set_method = self._lib.ECDH_set_method
-        self._lib.ECDH_set_method.restype = ctypes.c_int
-        self._lib.ECDH_set_method.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-
         self.ECDH_compute_key = self._lib.ECDH_compute_key
         self.ECDH_compute_key.restype = ctypes.c_int
         self.ECDH_compute_key.argtypes = [ctypes.c_void_p,

--- a/src/lib/ecies/openssl.py
+++ b/src/lib/ecies/openssl.py
@@ -33,26 +33,6 @@ import ctypes.util
 OpenSSL = None
 
 
-class CipherName:
-    def __init__(self, name, pointer, blocksize):
-        self._name = name
-        self._pointer = pointer
-        self._blocksize = blocksize
-
-    def __str__(self):
-        return ("Cipher : %s | Blocksize : %s | Fonction pointer : %s" %
-                (self._name, str(self._blocksize), str(self._pointer)))
-
-    def get_pointer(self):
-        return self._pointer()
-
-    def get_name(self):
-        return self._name
-
-    def get_blocksize(self):
-        return self._blocksize
-
-
 class _OpenSSL:
     """
     Wrapper for OpenSSL using ctypes
@@ -68,21 +48,9 @@ class _OpenSSL:
         self.byref = ctypes.byref
         self.create_string_buffer = ctypes.create_string_buffer
 
-        self.BN_new = self._lib.BN_new
-        self.BN_new.restype = ctypes.c_void_p
-        self.BN_new.argtypes = []
-
         self.BN_free = self._lib.BN_free
         self.BN_free.restype = None
         self.BN_free.argtypes = [ctypes.c_void_p]
-
-        self.BN_num_bits = self._lib.BN_num_bits
-        self.BN_num_bits.restype = ctypes.c_int
-        self.BN_num_bits.argtypes = [ctypes.c_void_p]
-
-        self.BN_bn2bin = self._lib.BN_bn2bin
-        self.BN_bn2bin.restype = ctypes.c_int
-        self.BN_bn2bin.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
         self.BN_bin2bn = self._lib.BN_bin2bn
         self.BN_bin2bn.restype = ctypes.c_void_p
@@ -97,29 +65,13 @@ class _OpenSSL:
         self.EC_KEY_new_by_curve_name.restype = ctypes.c_void_p
         self.EC_KEY_new_by_curve_name.argtypes = [ctypes.c_int]
 
-        self.EC_KEY_generate_key = self._lib.EC_KEY_generate_key
-        self.EC_KEY_generate_key.restype = ctypes.c_int
-        self.EC_KEY_generate_key.argtypes = [ctypes.c_void_p]
-
         self.EC_KEY_check_key = self._lib.EC_KEY_check_key
         self.EC_KEY_check_key.restype = ctypes.c_int
         self.EC_KEY_check_key.argtypes = [ctypes.c_void_p]
 
-        self.EC_KEY_get0_private_key = self._lib.EC_KEY_get0_private_key
-        self.EC_KEY_get0_private_key.restype = ctypes.c_void_p
-        self.EC_KEY_get0_private_key.argtypes = [ctypes.c_void_p]
-
-        self.EC_KEY_get0_public_key = self._lib.EC_KEY_get0_public_key
-        self.EC_KEY_get0_public_key.restype = ctypes.c_void_p
-        self.EC_KEY_get0_public_key.argtypes = [ctypes.c_void_p]
-
         self.EC_KEY_get0_group = self._lib.EC_KEY_get0_group
         self.EC_KEY_get0_group.restype = ctypes.c_void_p
         self.EC_KEY_get0_group.argtypes = [ctypes.c_void_p]
-
-        self.EC_POINT_get_affine_coordinates_GFp = self._lib.EC_POINT_get_affine_coordinates_GFp
-        self.EC_POINT_get_affine_coordinates_GFp.restype = ctypes.c_int
-        self.EC_POINT_get_affine_coordinates_GFp.argtypes = 5 * [ctypes.c_void_p]
 
         self.EC_KEY_set_private_key = self._lib.EC_KEY_set_private_key
         self.EC_KEY_set_private_key.restype = ctypes.c_int
@@ -130,10 +82,6 @@ class _OpenSSL:
         self.EC_KEY_set_public_key.restype = ctypes.c_int
         self.EC_KEY_set_public_key.argtypes = [ctypes.c_void_p,
                                                ctypes.c_void_p]
-
-        self.EC_KEY_set_group = self._lib.EC_KEY_set_group
-        self.EC_KEY_set_group.restype = ctypes.c_int
-        self.EC_KEY_set_group.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
 
         self.EC_POINT_set_affine_coordinates_GFp = self._lib.EC_POINT_set_affine_coordinates_GFp
         self.EC_POINT_set_affine_coordinates_GFp.restype = ctypes.c_int
@@ -147,16 +95,6 @@ class _OpenSSL:
         self.EC_POINT_free.restype = None
         self.EC_POINT_free.argtypes = [ctypes.c_void_p]
 
-        self.BN_CTX_free = self._lib.BN_CTX_free
-        self.BN_CTX_free.restype = None
-        self.BN_CTX_free.argtypes = [ctypes.c_void_p]
-
-        self.EC_POINT_mul = self._lib.EC_POINT_mul
-        self.EC_POINT_mul.restype = ctypes.c_int
-        self.EC_POINT_mul.argtypes = [ctypes.c_void_p, ctypes.c_void_p,
-                                      ctypes.c_void_p, ctypes.c_void_p,
-                                      ctypes.c_void_p, ctypes.c_void_p]
-
         self.EC_KEY_set_private_key = self._lib.EC_KEY_set_private_key
         self.EC_KEY_set_private_key.restype = ctypes.c_int
         self.EC_KEY_set_private_key.argtypes = [ctypes.c_void_p,
@@ -165,10 +103,6 @@ class _OpenSSL:
         self.ECDH_OpenSSL = self._lib.ECDH_OpenSSL
         self._lib.ECDH_OpenSSL.restype = ctypes.c_void_p
         self._lib.ECDH_OpenSSL.argtypes = []
-
-        self.BN_CTX_new = self._lib.BN_CTX_new
-        self._lib.BN_CTX_new.restype = ctypes.c_void_p
-        self._lib.BN_CTX_new.argtypes = []
 
         self.ECDH_set_method = self._lib.ECDH_set_method
         self._lib.ECDH_set_method.restype = ctypes.c_int
@@ -181,321 +115,23 @@ class _OpenSSL:
                                           ctypes.c_void_p,
                                           ctypes.c_void_p]
 
-        self.EVP_CipherInit_ex = self._lib.EVP_CipherInit_ex
-        self.EVP_CipherInit_ex.restype = ctypes.c_int
-        self.EVP_CipherInit_ex.argtypes = [ctypes.c_void_p,
-                                           ctypes.c_void_p, ctypes.c_void_p]
-
-        self.EVP_CIPHER_CTX_new = self._lib.EVP_CIPHER_CTX_new
-        self.EVP_CIPHER_CTX_new.restype = ctypes.c_void_p
-        self.EVP_CIPHER_CTX_new.argtypes = []
-
-        # Cipher
-        self.EVP_aes_128_cfb128 = self._lib.EVP_aes_128_cfb128
-        self.EVP_aes_128_cfb128.restype = ctypes.c_void_p
-        self.EVP_aes_128_cfb128.argtypes = []
-
-        self.EVP_aes_256_cfb128 = self._lib.EVP_aes_256_cfb128
-        self.EVP_aes_256_cfb128.restype = ctypes.c_void_p
-        self.EVP_aes_256_cfb128.argtypes = []
-
-        self.EVP_aes_128_cbc = self._lib.EVP_aes_128_cbc
-        self.EVP_aes_128_cbc.restype = ctypes.c_void_p
-        self.EVP_aes_128_cbc.argtypes = []
-
-        self.EVP_aes_256_cbc = self._lib.EVP_aes_256_cbc
-        self.EVP_aes_256_cbc.restype = ctypes.c_void_p
-        self.EVP_aes_256_cbc.argtypes = []
-
-        try:
-            self.EVP_aes_128_ctr = self._lib.EVP_aes_128_ctr
-        except AttributeError:
-            pass
-        else:
-            self.EVP_aes_128_ctr.restype = ctypes.c_void_p
-            self.EVP_aes_128_ctr.argtypes = []
-
-        try:
-            self.EVP_aes_256_ctr = self._lib.EVP_aes_256_ctr
-        except AttributeError:
-            pass
-        else:
-            self.EVP_aes_256_ctr.restype = ctypes.c_void_p
-            self.EVP_aes_256_ctr.argtypes = []
-
-        self.EVP_aes_128_ofb = self._lib.EVP_aes_128_ofb
-        self.EVP_aes_128_ofb.restype = ctypes.c_void_p
-        self.EVP_aes_128_ofb.argtypes = []
-
-        self.EVP_aes_256_ofb = self._lib.EVP_aes_256_ofb
-        self.EVP_aes_256_ofb.restype = ctypes.c_void_p
-        self.EVP_aes_256_ofb.argtypes = []
-
-        self.EVP_bf_cbc = self._lib.EVP_bf_cbc
-        self.EVP_bf_cbc.restype = ctypes.c_void_p
-        self.EVP_bf_cbc.argtypes = []
-
-        self.EVP_bf_cfb64 = self._lib.EVP_bf_cfb64
-        self.EVP_bf_cfb64.restype = ctypes.c_void_p
-        self.EVP_bf_cfb64.argtypes = []
-
-        self.EVP_rc4 = self._lib.EVP_rc4
-        self.EVP_rc4.restype = ctypes.c_void_p
-        self.EVP_rc4.argtypes = []
-
-        self.EVP_CIPHER_CTX_cleanup = self._lib.EVP_CIPHER_CTX_cleanup
-        self.EVP_CIPHER_CTX_cleanup.restype = ctypes.c_int
-        self.EVP_CIPHER_CTX_cleanup.argtypes = [ctypes.c_void_p]
-
-        self.EVP_CIPHER_CTX_free = self._lib.EVP_CIPHER_CTX_free
-        self.EVP_CIPHER_CTX_free.restype = None
-        self.EVP_CIPHER_CTX_free.argtypes = [ctypes.c_void_p]
-
-        self.EVP_CipherUpdate = self._lib.EVP_CipherUpdate
-        self.EVP_CipherUpdate.restype = ctypes.c_int
-        self.EVP_CipherUpdate.argtypes = [ctypes.c_void_p,
-                                          ctypes.c_void_p,
-                                          ctypes.c_void_p,
-                                          ctypes.c_void_p,
-                                          ctypes.c_int]
-
-        self.EVP_CipherFinal_ex = self._lib.EVP_CipherFinal_ex
-        self.EVP_CipherFinal_ex.restype = ctypes.c_int
-        self.EVP_CipherFinal_ex.argtypes = 3 * [ctypes.c_void_p]
-
-        self.EVP_DigestInit = self._lib.EVP_DigestInit
-        self.EVP_DigestInit.restype = ctypes.c_int
-        self._lib.EVP_DigestInit.argtypes = 2 * [ctypes.c_void_p]
-
-        self.EVP_DigestUpdate = self._lib.EVP_DigestUpdate
-        self.EVP_DigestUpdate.restype = ctypes.c_int
-        self.EVP_DigestUpdate.argtypes = [ctypes.c_void_p,
-                                          ctypes.c_void_p,
-                                          ctypes.c_int]
-
-        self.EVP_DigestFinal = self._lib.EVP_DigestFinal
-        self.EVP_DigestFinal.restype = ctypes.c_int
-        self.EVP_DigestFinal.argtypes = [ctypes.c_void_p,
-                                         ctypes.c_void_p, ctypes.c_void_p]
-
-        self.EVP_ecdsa = self._lib.EVP_ecdsa
-        self._lib.EVP_ecdsa.restype = ctypes.c_void_p
-        self._lib.EVP_ecdsa.argtypes = []
-
-        self.ECDSA_sign = self._lib.ECDSA_sign
-        self.ECDSA_sign.restype = ctypes.c_int
-        self.ECDSA_sign.argtypes = [ctypes.c_int,
-                                    ctypes.c_void_p,
-                                    ctypes.c_int,
-                                    ctypes.c_void_p,
-                                    ctypes.c_void_p,
-                                    ctypes.c_void_p]
-
-        self.ECDSA_verify = self._lib.ECDSA_verify
-        self.ECDSA_verify.restype = ctypes.c_int
-        self.ECDSA_verify.argtypes = [ctypes.c_int,
-                                      ctypes.c_void_p,
-                                      ctypes.c_int,
-                                      ctypes.c_void_p,
-                                      ctypes.c_int,
-                                      ctypes.c_void_p]
-
-        self.EVP_MD_CTX_create = self._lib.EVP_MD_CTX_create
-        self.EVP_MD_CTX_create.restype = ctypes.c_void_p
-        self.EVP_MD_CTX_create.argtypes = []
-
-        self.EVP_MD_CTX_init = self._lib.EVP_MD_CTX_init
-        self.EVP_MD_CTX_init.restype = None
-        self.EVP_MD_CTX_init.argtypes = [ctypes.c_void_p]
-
-        self.EVP_MD_CTX_destroy = self._lib.EVP_MD_CTX_destroy
-        self.EVP_MD_CTX_destroy.restype = None
-        self.EVP_MD_CTX_destroy.argtypes = [ctypes.c_void_p]
-
-        self.RAND_bytes = self._lib.RAND_bytes
-        self.RAND_bytes.restype = ctypes.c_int
-        self.RAND_bytes.argtypes = [ctypes.c_void_p, ctypes.c_int]
-
-        self.EVP_sha256 = self._lib.EVP_sha256
-        self.EVP_sha256.restype = ctypes.c_void_p
-        self.EVP_sha256.argtypes = []
-
-        self.i2o_ECPublicKey = self._lib.i2o_ECPublicKey
-        self.i2o_ECPublicKey.restype = ctypes.c_int
-        self.i2o_ECPublicKey.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
-
-        self.EVP_sha512 = self._lib.EVP_sha512
-        self.EVP_sha512.restype = ctypes.c_void_p
-        self.EVP_sha512.argtypes = []
-
-        self.HMAC = self._lib.HMAC
-        self.HMAC.restype = ctypes.c_void_p
-        self.HMAC.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int,
-                              ctypes.c_void_p, ctypes.c_int,
-                              ctypes.c_void_p, ctypes.c_void_p]
-
-        try:
-            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC
-        except:
-            # The above is not compatible with all versions of OSX.
-            self.PKCS5_PBKDF2_HMAC = self._lib.PKCS5_PBKDF2_HMAC_SHA1
-        self.PKCS5_PBKDF2_HMAC.restype = ctypes.c_int
-        self.PKCS5_PBKDF2_HMAC.argtypes = [ctypes.c_void_p, ctypes.c_int,
-                                           ctypes.c_void_p, ctypes.c_int,
-                                           ctypes.c_int, ctypes.c_void_p,
-                                           ctypes.c_int, ctypes.c_void_p]
-
-        self._set_ciphers()
-        self._set_curves()
-
-    def _set_ciphers(self):
-        self.cipher_algo = {
-            'aes-128-cbc': CipherName('aes-128-cbc',
-                                      self.EVP_aes_128_cbc,
-                                      16),
-            'aes-256-cbc': CipherName('aes-256-cbc',
-                                      self.EVP_aes_256_cbc,
-                                      16),
-            'aes-128-cfb': CipherName('aes-128-cfb',
-                                      self.EVP_aes_128_cfb128,
-                                      16),
-            'aes-256-cfb': CipherName('aes-256-cfb',
-                                      self.EVP_aes_256_cfb128,
-                                      16),
-            'aes-128-ofb': CipherName('aes-128-ofb',
-                                      self._lib.EVP_aes_128_ofb,
-                                      16),
-            'aes-256-ofb': CipherName('aes-256-ofb',
-                                      self._lib.EVP_aes_256_ofb,
-                                      16),
-            # 'aes-128-ctr': CipherName('aes-128-ctr',
-            #                           self._lib.EVP_aes_128_ctr,
-            #                           16),
-            # 'aes-256-ctr': CipherName('aes-256-ctr',
-            #                           self._lib.EVP_aes_256_ctr,
-            #                           16),
-            'bf-cfb': CipherName('bf-cfb',
-                                 self.EVP_bf_cfb64,
-                                 8),
-            'bf-cbc': CipherName('bf-cbc',
-                                 self.EVP_bf_cbc,
-                                 8),
-            'rc4': CipherName('rc4',
-                              self.EVP_rc4,
-                              # 128 is the initialisation size not block size
-                              128),
-        }
-
-        if hasattr(self, 'EVP_aes_128_ctr'):
-            self.cipher_algo['aes-128-ctr'] = CipherName(
-                'aes-128-ctr',
-                self._lib.EVP_aes_128_ctr,
-                16
-            )
-        if hasattr(self, 'EVP_aes_256_ctr'):
-            self.cipher_algo['aes-256-ctr'] = CipherName(
-                'aes-256-ctr',
-                self._lib.EVP_aes_256_ctr,
-                16
-            )
-
-    def _set_curves(self):
-        self.curves = {
-            'secp112r1': 704,
-            'secp112r2': 705,
-            'secp128r1': 706,
-            'secp128r2': 707,
-            'secp160k1': 708,
-            'secp160r1': 709,
-            'secp160r2': 710,
-            'secp192k1': 711,
-            'secp224k1': 712,
-            'secp224r1': 713,
-            'secp256k1': 714,
-            'secp384r1': 715,
-            'secp521r1': 716,
-            'sect113r1': 717,
-            'sect113r2': 718,
-            'sect131r1': 719,
-            'sect131r2': 720,
-            'sect163k1': 721,
-            'sect163r1': 722,
-            'sect163r2': 723,
-            'sect193r1': 724,
-            'sect193r2': 725,
-            'sect233k1': 726,
-            'sect233r1': 727,
-            'sect239k1': 728,
-            'sect283k1': 729,
-            'sect283r1': 730,
-            'sect409k1': 731,
-            'sect409r1': 732,
-            'sect571k1': 733,
-            'sect571r1': 734,
-            'prime256v1': 415,
-        }
-
-    def BN_num_bytes(self, x):
-        """
-        returns the length of a BN (OpenSSl API)
-        """
-        return int((self.BN_num_bits(x) + 7) / 8)
-
-    def get_cipher(self, name):
-        """
-        returns the OpenSSL cipher instance
-        """
-        if name not in self.cipher_algo:
-            raise Exception("Unknown cipher")
-        return self.cipher_algo[name]
-
-    def get_curve(self, name):
-        """
-        returns the id of a elliptic curve
-        """
-        if name not in self.curves:
-            raise Exception("Unknown curve")
-        return self.curves[name]
-
-    def get_curve_by_id(self, id):
-        """
-        returns the name of a elliptic curve with his id
-        """
-        res = None
-        for i in self.curves:
-            if self.curves[i] == id:
-                res = i
-                break
-        if res is None:
-            raise Exception("Unknown curve")
-        return res
-
-    def rand(self, size):
-        """
-        OpenSSL random function
-        """
-        buffer = self.malloc(0, size)
-        if self.RAND_bytes(buffer, size) != 1:
-            raise RuntimeError("OpenSSL RAND_bytes failed")
-        return buffer.raw
-
     def malloc(self, data, size):
         """
         returns a create_string_buffer (ctypes)
         """
         buffer = None
         if data != 0:
-            if sys.version_info.major == 3 and isinstance(data, type('')):
+            if sys.version_info.major == 3 and isinstance(data, type("")):
                 data = data.encode()
             buffer = self.create_string_buffer(data, size)
         else:
             buffer = self.create_string_buffer(size)
         return buffer
 
-libname = ctypes.util.find_library('crypto')
+libname = ctypes.util.find_library("crypto")
 if libname is None:
     # For Windows ...
-    libname = ctypes.util.find_library('libeay32.dll')
+    libname = ctypes.util.find_library("libeay32.dll")
 if libname is None:
     raise Exception("Couldn't load OpenSSL lib ...")
 OpenSSL = _OpenSSL(libname)

--- a/src/lib/ecies/pack.py
+++ b/src/lib/ecies/pack.py
@@ -1,0 +1,52 @@
+from struct import unpack, pack
+
+
+def parseEciesData(data):
+    # IV
+    iv = data[:16]
+    data = data[16:]
+    # Curve
+    curve = unpack("!H", data[:2])[0]
+    data = data[2:]
+    # X
+    x_len = unpack("!H", data[:2])[0]
+    data = data[2:]
+    publickey_x = int.from_bytes(data[:x_len], byteorder="big")
+    data = data[x_len:]
+    # Y
+    y_len = unpack("!H", data[:2])[0]
+    data = data[2:]
+    publickey_y = int.from_bytes(data[:y_len], byteorder="big")
+    data = data[y_len:]
+    # Ciphertext
+    ciphertext = data[:-32]
+    # MAC
+    mac = data[-32:]
+
+    return {
+        "iv": iv,
+        "curve": curve,
+        "publickey": (publickey_x, publickey_y),
+        "ciphertext": ciphertext,
+        "mac": mac
+    }
+
+
+
+def encodeEciesData(data):
+    return (
+        # IV
+        data["iv"] +
+        # Curve
+        pack("!H", data["curve"]) +
+        # X
+        pack("!H", 32) +
+        data["publickey"][0].to_bytes(32, byteorder="big") +
+        # Y
+        pack("!H", 32) +
+        data["publickey"][1].to_bytes(32, byteorder="big") +
+        # Ciphertext
+        data["ciphertext"] +
+        # MAC
+        data["mac"]
+    )


### PR DESCRIPTION
So I got tired of this dependency we are all talking about. This PR replaces `pyelliptic` with other libraries.

1. For AES, I use `pycryptodome` (see `plugins/CryptMessage/CryptMessagePlugin.py`). It's simple to use and should be simple to maintain:
```python
cipher = AES.new(key, AES.MODE_CBC, iv)
encrypted = cipher.encrypt(pad(text, AES.block_size))
```

2. For ECIES, I wrote my own library. I've tested it on your tests, and compared the binary data with some other data, and I'm sure it works correctly. The format is compatible with pyelliptic's format (though I think that this format is weird and seldom used). For key derivation (ECDH), I used some code from `pyelliptic` and fixed it to be compatible with modern OpenSSL (according to the docs). For the AES stage, I use `pycryptodome`. For MAC, I use the standard `hmac` module (preinstalled).