### PR TITLE
Bigfile: fix piece field bitmask to be used as bytearray consistently

### DIFF
--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -324,7 +324,7 @@ class ContentManagerPlugin(object):
         # Add the merkle root to hashfield
         hash_id = self.site.content_manager.hashfield.getHashId(hash)
         self.optionalDownloaded(inner_path, hash_id, file_size, own=True)
-        self.site.storage.piecefields[hash].fromstring(b"\x01" * piece_num)
+        self.site.storage.piecefields[hash].frombytes(b"\x01" * piece_num)
 
         back[file_relative_path] = {"sha512": hash, "size": file_size, "piecemap": piecemap_relative_path, "piece_size": piece_size}
         return back
@@ -464,11 +464,11 @@ class SiteStoragePlugin(object):
                 else:
                     piece_data = b"\x01"
                 self.log.debug("%s: File exists, but not in piecefield. Filling piecefiled with %s * %s." % (inner_path, piece_num, piece_data))
-                self.piecefields[sha512].fromstring(piece_data * piece_num)
+                self.piecefields[sha512].frombytes(piece_data * piece_num)
         else:
             self.log.debug("Creating bigfile: %s" % inner_path)
             self.createSparseFile(inner_path, file_info["size"], sha512)
-            self.piecefields[sha512].fromstring(b"\x00" * piece_num)
+            self.piecefields[sha512].frombytes(b"\x00" * piece_num)
             self.log.debug("Created bigfile: %s" % inner_path)
         return True
 
@@ -596,7 +596,7 @@ class WorkerManagerPlugin(object):
             if not self.site.storage.isFile(inner_path):
                 self.site.storage.createSparseFile(inner_path, file_info["size"], file_info["sha512"])
                 piece_num = int(math.ceil(float(file_info["size"]) / file_info["piece_size"]))
-                self.site.storage.piecefields[file_info["sha512"]].fromstring(b"\x00" * piece_num)
+                self.site.storage.piecefields[file_info["sha512"]].frombytes(b"\x00" * piece_num)
         else:
             task = super(WorkerManagerPlugin, self).addTask(inner_path, *args, **kwargs)
         return task

--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -324,7 +324,7 @@ class ContentManagerPlugin(object):
         # Add the merkle root to hashfield
         hash_id = self.site.content_manager.hashfield.getHashId(hash)
         self.optionalDownloaded(inner_path, hash_id, file_size, own=True)
-        self.site.storage.piecefields[hash].fromstring("1" * piece_num)
+        self.site.storage.piecefields[hash].fromstring(b"1" * piece_num)
 
         back[file_relative_path] = {"sha512": hash, "size": file_size, "piecemap": piecemap_relative_path, "piece_size": piece_size}
         return back
@@ -460,15 +460,16 @@ class SiteStoragePlugin(object):
         if os.path.isfile(file_path):
             if sha512 not in self.piecefields:
                 if open(file_path, "rb").read(128) == b"\0" * 128:
-                    piece_data = "0"
+                    piece_data = b"0"
                 else:
-                    piece_data = "1"
+                    piece_data = b"1"
                 self.log.debug("%s: File exists, but not in piecefield. Filling piecefiled with %s * %s." % (inner_path, piece_num, piece_data))
                 self.piecefields[sha512].fromstring(piece_data * piece_num)
         else:
             self.log.debug("Creating bigfile: %s" % inner_path)
             self.createSparseFile(inner_path, file_info["size"], sha512)
-            self.piecefields[sha512].fromstring("0" * piece_num)
+            self.piecefields[sha512].fromstring(b"0" * piece_num)
+            self.log.debug("Created bigfile: %s" % inner_path)
         return True
 
     def openBigfile(self, inner_path, prebuffer=0):
@@ -595,7 +596,7 @@ class WorkerManagerPlugin(object):
             if not self.site.storage.isFile(inner_path):
                 self.site.storage.createSparseFile(inner_path, file_info["size"], file_info["sha512"])
                 piece_num = int(math.ceil(float(file_info["size"]) / file_info["piece_size"]))
-                self.site.storage.piecefields[file_info["sha512"]].fromstring("0" * piece_num)
+                self.site.storage.piecefields[file_info["sha512"]].fromstring(b"0" * piece_num)
         else:
             task = super(WorkerManagerPlugin, self).addTask(inner_path, *args, **kwargs)
         return task

--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -324,7 +324,7 @@ class ContentManagerPlugin(object):
         # Add the merkle root to hashfield
         hash_id = self.site.content_manager.hashfield.getHashId(hash)
         self.optionalDownloaded(inner_path, hash_id, file_size, own=True)
-        self.site.storage.piecefields[hash].fromstring(b"1" * piece_num)
+        self.site.storage.piecefields[hash].fromstring(b"\x01" * piece_num)
 
         back[file_relative_path] = {"sha512": hash, "size": file_size, "piecemap": piecemap_relative_path, "piece_size": piece_size}
         return back
@@ -361,7 +361,7 @@ class ContentManagerPlugin(object):
 
             # Mark piece downloaded
             piece_i = int(pos_from / file_info["piece_size"])
-            self.site.storage.piecefields[file_info["sha512"]][piece_i] = True
+            self.site.storage.piecefields[file_info["sha512"]][piece_i] = b"\x01"
 
             # Only add to site size on first request
             if hash_id in self.hashfield:
@@ -460,15 +460,15 @@ class SiteStoragePlugin(object):
         if os.path.isfile(file_path):
             if sha512 not in self.piecefields:
                 if open(file_path, "rb").read(128) == b"\0" * 128:
-                    piece_data = b"0"
+                    piece_data = b"\x00"
                 else:
-                    piece_data = b"1"
+                    piece_data = b"\x01"
                 self.log.debug("%s: File exists, but not in piecefield. Filling piecefiled with %s * %s." % (inner_path, piece_num, piece_data))
                 self.piecefields[sha512].fromstring(piece_data * piece_num)
         else:
             self.log.debug("Creating bigfile: %s" % inner_path)
             self.createSparseFile(inner_path, file_info["size"], sha512)
-            self.piecefields[sha512].fromstring(b"0" * piece_num)
+            self.piecefields[sha512].fromstring(b"\x00" * piece_num)
             self.log.debug("Created bigfile: %s" % inner_path)
         return True
 
@@ -596,7 +596,7 @@ class WorkerManagerPlugin(object):
             if not self.site.storage.isFile(inner_path):
                 self.site.storage.createSparseFile(inner_path, file_info["size"], file_info["sha512"])
                 piece_num = int(math.ceil(float(file_info["size"]) / file_info["piece_size"]))
-                self.site.storage.piecefields[file_info["sha512"]].fromstring(b"0" * piece_num)
+                self.site.storage.piecefields[file_info["sha512"]].fromstring(b"\x00" * piece_num)
         else:
             task = super(WorkerManagerPlugin, self).addTask(inner_path, *args, **kwargs)
         return task

--- a/plugins/Bigfile/Test/TestBigfile.py
+++ b/plugins/Bigfile/Test/TestBigfile.py
@@ -138,7 +138,7 @@ class TestBigfile:
         assert not bad_files
 
         # client_piecefield = peer_client.piecefields[file_info["sha512"]].tostring()
-        # assert client_piecefield == "1" * 10
+        # assert client_piecefield == b"1" * 10
 
         # Download 5. and 10. block
 
@@ -187,7 +187,7 @@ class TestBigfile:
 
             assert set(site_temp.content_manager.hashfield) == set([18343, 43727])
 
-            assert site_temp.storage.piecefields[f.sha512].tostring() == "0000010001"
+            assert site_temp.storage.piecefields[f.sha512].tostring() == b"0000010001"
             assert f.sha512 in site_temp.getSettingsCache()["piecefields"]
 
             # Test requesting already downloaded
@@ -219,20 +219,20 @@ class TestBigfile:
     @pytest.mark.parametrize("piecefield_obj", [BigfilePiecefield, BigfilePiecefieldPacked])
     def testPiecefield(self, piecefield_obj, site):
         testdatas = [
-            "1" * 100 + "0" * 900 + "1" * 4000 + "0" * 4999 + "1",
-            "010101" * 10 + "01" * 90 + "10" * 400 + "0" * 4999,
-            "1" * 10000,
-            "0" * 10000
+            b"1" * 100 + b"0" * 900 + b"1" * 4000 + b"0" * 4999 + b"1",
+            b"010101" * 10 + b"01" * 90 + b"10" * 400 + b"0" * 4999,
+            b"1" * 10000,
+            b"0" * 10000
         ]
         for testdata in testdatas:
             piecefield = piecefield_obj()
 
             piecefield.fromstring(testdata)
             assert piecefield.tostring() == testdata
-            assert piecefield[0] == int(testdata[0])
-            assert piecefield[100] == int(testdata[100])
-            assert piecefield[1000] == int(testdata[1000])
-            assert piecefield[len(testdata) - 1] == int(testdata[len(testdata) - 1])
+            assert piecefield[0] == int(chr(testdata[0]))
+            assert piecefield[100] == int(chr(testdata[100]))
+            assert piecefield[1000] == int(chr(testdata[1000]))
+            assert piecefield[len(testdata) - 1] == int(chr(testdata[len(testdata) - 1]))
 
             packed = piecefield.pack()
             piecefield_new = piecefield_obj()
@@ -345,7 +345,7 @@ class TestBigfile:
         # Create 10 fake peer for each piece
         for i in range(10):
             peer = Peer(file_server.ip, 1544, site_temp, server2)
-            peer.piecefields[sha512][i] = "1"
+            peer.piecefields[sha512][i] = b"1"
             peer.updateHashfield = mock.MagicMock(return_value=False)
             peer.updatePiecefields = mock.MagicMock(return_value=False)
             peer.findHashIds = mock.MagicMock(return_value={"nope": []})
@@ -430,7 +430,7 @@ class TestBigfile:
             time.sleep(0.5)  # Wait prebuffer download
 
             sha512 = site.content_manager.getFileInfo(inner_path)["sha512"]
-            assert site_temp.storage.piecefields[sha512].tostring() == "0000011100"
+            assert site_temp.storage.piecefields[sha512].tostring() == b"0000011100"
 
             # No prebuffer beyond end of the file
             f.seek(9 * 1024 * 1024)

--- a/plugins/Bigfile/Test/TestBigfile.py
+++ b/plugins/Bigfile/Test/TestBigfile.py
@@ -138,7 +138,7 @@ class TestBigfile:
         assert not bad_files
 
         # client_piecefield = peer_client.piecefields[file_info["sha512"]].tostring()
-        # assert client_piecefield == b"1" * 10
+        # assert client_piecefield == b"\x01" * 10
 
         # Download 5. and 10. block
 
@@ -187,7 +187,7 @@ class TestBigfile:
 
             assert set(site_temp.content_manager.hashfield) == set([18343, 43727])
 
-            assert site_temp.storage.piecefields[f.sha512].tostring() == b"0000010001"
+            assert site_temp.storage.piecefields[f.sha512].tostring() == b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01"
             assert f.sha512 in site_temp.getSettingsCache()["piecefields"]
 
             # Test requesting already downloaded
@@ -219,20 +219,20 @@ class TestBigfile:
     @pytest.mark.parametrize("piecefield_obj", [BigfilePiecefield, BigfilePiecefieldPacked])
     def testPiecefield(self, piecefield_obj, site):
         testdatas = [
-            b"1" * 100 + b"0" * 900 + b"1" * 4000 + b"0" * 4999 + b"1",
-            b"010101" * 10 + b"01" * 90 + b"10" * 400 + b"0" * 4999,
-            b"1" * 10000,
-            b"0" * 10000
+            b"\x01" * 100 + b"\x00" * 900 + b"\x01" * 4000 + b"\x00" * 4999 + b"\x01",
+            b"\x00\x01\x00\x01\x00\x01" * 10 + b"\x00\x01" * 90 + b"\x01\x00" * 400 + b"\x00" * 4999,
+            b"\x01" * 10000,
+            b"\x00" * 10000
         ]
         for testdata in testdatas:
             piecefield = piecefield_obj()
 
             piecefield.fromstring(testdata)
             assert piecefield.tostring() == testdata
-            assert piecefield[0] == int(chr(testdata[0]))
-            assert piecefield[100] == int(chr(testdata[100]))
-            assert piecefield[1000] == int(chr(testdata[1000]))
-            assert piecefield[len(testdata) - 1] == int(chr(testdata[len(testdata) - 1]))
+            assert piecefield[0] == testdata[0]
+            assert piecefield[100] == testdata[100]
+            assert piecefield[1000] == testdata[1000]
+            assert piecefield[len(testdata) - 1] == testdata[len(testdata) - 1]
 
             packed = piecefield.pack()
             piecefield_new = piecefield_obj()
@@ -345,7 +345,7 @@ class TestBigfile:
         # Create 10 fake peer for each piece
         for i in range(10):
             peer = Peer(file_server.ip, 1544, site_temp, server2)
-            peer.piecefields[sha512][i] = b"1"
+            peer.piecefields[sha512][i] = b"\x01"
             peer.updateHashfield = mock.MagicMock(return_value=False)
             peer.updatePiecefields = mock.MagicMock(return_value=False)
             peer.findHashIds = mock.MagicMock(return_value={"nope": []})
@@ -430,7 +430,7 @@ class TestBigfile:
             time.sleep(0.5)  # Wait prebuffer download
 
             sha512 = site.content_manager.getFileInfo(inner_path)["sha512"]
-            assert site_temp.storage.piecefields[sha512].tostring() == b"0000011100"
+            assert site_temp.storage.piecefields[sha512].tostring() == b"\x00\x00\x00\x00\x00\x01\x01\x01\x00\x00"
 
             # No prebuffer beyond end of the file
             f.seek(9 * 1024 * 1024)

--- a/plugins/Bigfile/Test/TestBigfile.py
+++ b/plugins/Bigfile/Test/TestBigfile.py
@@ -137,7 +137,7 @@ class TestBigfile:
         bad_files = site_temp.storage.verifyFiles(quick_check=True)["bad_files"]
         assert not bad_files
 
-        # client_piecefield = peer_client.piecefields[file_info["sha512"]].tostring()
+        # client_piecefield = peer_client.piecefields[file_info["sha512"]].tobytes()
         # assert client_piecefield == b"\x01" * 10
 
         # Download 5. and 10. block
@@ -187,7 +187,7 @@ class TestBigfile:
 
             assert set(site_temp.content_manager.hashfield) == set([18343, 43727])
 
-            assert site_temp.storage.piecefields[f.sha512].tostring() == b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01"
+            assert site_temp.storage.piecefields[f.sha512].tobytes() == b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x01"
             assert f.sha512 in site_temp.getSettingsCache()["piecefields"]
 
             # Test requesting already downloaded
@@ -227,8 +227,8 @@ class TestBigfile:
         for testdata in testdatas:
             piecefield = piecefield_obj()
 
-            piecefield.fromstring(testdata)
-            assert piecefield.tostring() == testdata
+            piecefield.frombytes(testdata)
+            assert piecefield.tobytes() == testdata
             assert piecefield[0] == testdata[0]
             assert piecefield[100] == testdata[100]
             assert piecefield[1000] == testdata[1000]
@@ -237,8 +237,8 @@ class TestBigfile:
             packed = piecefield.pack()
             piecefield_new = piecefield_obj()
             piecefield_new.unpack(packed)
-            assert piecefield.tostring() == piecefield_new.tostring()
-            assert piecefield_new.tostring() == testdata
+            assert piecefield.tobytes() == piecefield_new.tobytes()
+            assert piecefield_new.tobytes() == testdata
 
     def testFileGet(self, file_server, site, site_temp):
         inner_path = self.createBigfile(site)
@@ -430,7 +430,7 @@ class TestBigfile:
             time.sleep(0.5)  # Wait prebuffer download
 
             sha512 = site.content_manager.getFileInfo(inner_path)["sha512"]
-            assert site_temp.storage.piecefields[sha512].tostring() == b"\x00\x00\x00\x00\x00\x01\x01\x01\x00\x00"
+            assert site_temp.storage.piecefields[sha512].tobytes() == b"\x00\x00\x00\x00\x00\x01\x01\x01\x00\x00"
 
             # No prebuffer beyond end of the file
             f.seek(9 * 1024 * 1024)

--- a/plugins/OptionalManager/UiWebsocketPlugin.py
+++ b/plugins/OptionalManager/UiWebsocketPlugin.py
@@ -66,7 +66,7 @@ class UiWebsocketPlugin(object):
 
         if piecefield:
             row["pieces"] = len(piecefield)
-            row["pieces_downloaded"] = piecefield.count("1")
+            row["pieces_downloaded"] = piecefield.count(b"1")
             row["downloaded_percent"] = 100 * row["pieces_downloaded"] / row["pieces"]
             if row["pieces_downloaded"]:
                 if row["pieces"] == row["pieces_downloaded"]:
@@ -89,7 +89,7 @@ class UiWebsocketPlugin(object):
             peer_piecefield = peer.piecefields[sha512].tostring()
             if not peer_piecefield:
                 continue
-            if peer_piecefield == "1" * len(peer_piecefield):
+            if peer_piecefield == b"1" * len(peer_piecefield):
                 row["peer_seed"] += 1
             else:
                 row["peer_leech"] += 1

--- a/plugins/OptionalManager/UiWebsocketPlugin.py
+++ b/plugins/OptionalManager/UiWebsocketPlugin.py
@@ -66,7 +66,7 @@ class UiWebsocketPlugin(object):
 
         if piecefield:
             row["pieces"] = len(piecefield)
-            row["pieces_downloaded"] = piecefield.count(b"1")
+            row["pieces_downloaded"] = piecefield.count(b"\x01")
             row["downloaded_percent"] = 100 * row["pieces_downloaded"] / row["pieces"]
             if row["pieces_downloaded"]:
                 if row["pieces"] == row["pieces_downloaded"]:
@@ -89,7 +89,7 @@ class UiWebsocketPlugin(object):
             peer_piecefield = peer.piecefields[sha512].tostring()
             if not peer_piecefield:
                 continue
-            if peer_piecefield == b"1" * len(peer_piecefield):
+            if peer_piecefield == b"\x01" * len(peer_piecefield):
                 row["peer_seed"] += 1
             else:
                 row["peer_leech"] += 1

--- a/plugins/OptionalManager/UiWebsocketPlugin.py
+++ b/plugins/OptionalManager/UiWebsocketPlugin.py
@@ -60,7 +60,7 @@ class UiWebsocketPlugin(object):
             bigfile_sha512_cache[file_key] = sha512
 
         if sha512 in site.storage.piecefields:
-            piecefield = site.storage.piecefields[sha512].tostring()
+            piecefield = site.storage.piecefields[sha512].tobytes()
         else:
             piecefield = None
 
@@ -86,7 +86,7 @@ class UiWebsocketPlugin(object):
         for peer in site.peers.values():
             if not peer.time_piecefields_updated or sha512 not in peer.piecefields:
                 continue
-            peer_piecefield = peer.piecefields[sha512].tostring()
+            peer_piecefield = peer.piecefields[sha512].tobytes()
             if not peer_piecefield:
                 continue
             if peer_piecefield == b"\x01" * len(peer_piecefield):


### PR DESCRIPTION
Should fix #1980 and  the error in #1773#issuecomment-482436819

*    Bigfile: make Piecefield array a bytearray
    
We want an array of characters. Py2 strings made sense to
use as an array of characters, but Py3 strings are different
and no longer a good choice.

NOTE: we could also store `\x0` and `\x1` instead of `b'0'` and `b'1'`. This has the advantage of returning bitfield boolean with `data[key]` instead of having to do `int(chr(data[key]))` (note: `chr()` was not needed with Py2 strings because `"01"[0]=='0'` but `b"01")[0]==48`). If you want this additional change, I can add it.

*    Bigfile: remove encode call from piece bytearray

That value comes from hsahlib's digest return, which is a bytearray.
