### PR TITLE
OptionalManager file info - set bytes_downloaded to total file size if a file is fully downloaded

### DIFF
--- a/plugins/OptionalManager/UiWebsocketPlugin.py
+++ b/plugins/OptionalManager/UiWebsocketPlugin.py
@@ -69,9 +69,12 @@ class UiWebsocketPlugin(object):
             row["pieces_downloaded"] = piecefield.count("1")
             row["downloaded_percent"] = 100 * row["pieces_downloaded"] / row["pieces"]
             if row["pieces_downloaded"]:
-                if not file_info:
-                    file_info = site.content_manager.getFileInfo(row["inner_path"])
-                row["bytes_downloaded"] = row["pieces_downloaded"] * file_info.get("piece_size", 0)
+                if row["pieces"] == row["pieces_downloaded"]:
+                    row["bytes_downloaded"] = row["size"]
+                else:
+                    if not file_info:
+                        file_info = site.content_manager.getFileInfo(row["inner_path"])
+                    row["bytes_downloaded"] = row["pieces_downloaded"] * file_info.get("piece_size", 0)
             else:
                 row["bytes_downloaded"] = 0
 


### PR DESCRIPTION
In `optionalFileList` API command I saw a bug. If the file is 100% downloaded field `bytes_downloaded` contains an incorrect value.

e.g.
```
   bytes_downloaded: 677380096
   pieces: 646
   pieces_downloaded: 646
   size: 676612177
```

A number of `bytes_downloaded` is greater than the total size of the file - field `size`, because `bytes_downloaded` is calculated as `pieces * piece_size`.

I have fixed that problem. If a file is fully downloaded (`pieces` is equal to `pieces_downloaded`), set field `bytes_downloaded` to a value of `size`.

```
  bytes_downloaded: 676612177
  pieces: 646
  pieces_downloaded: 646
  size: 676612177
```