### PR TITLE
Ui, Translate: fix bytearray format string for Py 3.4

### DIFF
--- a/plugins/TranslateSite/TranslateSitePlugin.py
+++ b/plugins/TranslateSite/TranslateSitePlugin.py
@@ -57,7 +57,7 @@ class UiRequestPlugin(object):
         if not lang_file_exist or inner_path not in content_json.get("translate", []):
             for part in file_generator:
                 if inner_path.endswith(".html"):
-                    yield part.replace(b"lang={lang}", b"lang=%s" % translate.lang.encode("utf8"))  # lang get parameter to .js file to avoid cache
+                    yield part.replace(b"lang={lang}", b"lang=" + translate.lang.encode("utf8"))  # lang get parameter to .js file to avoid cache
                 else:
                     yield part
         else:

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -299,7 +299,7 @@ class UiRequest(object):
     # Redirect to an url
     def actionRedirect(self, url):
         self.start_response('301 Redirect', [('Location', str(url))])
-        yield b"Location changed: %s" % url.encode("utf8")
+        yield b"Location changed: " + url.encode("utf8")
 
     def actionIndex(self):
         return self.actionRedirect("/" + config.homepage)


### PR DESCRIPTION
Py 3.4 does not support bytearray format strings for % operator: b"%s" % s

Fixes on Python 3.4:
```
UiWSGIHandler error: TypeError: unsupported operand type(s) for %: 'bytes' and 'bytes' in UiServer.py line 41 > pywsgi.py line 924 > pywsgi.py line 908 > UiRequest.py line 302
```