### PR TITLE
Support for detection of system's theme

### DIFF
--- a/src/Ui/media/ZeroSiteTheme.coffee
+++ b/src/Ui/media/ZeroSiteTheme.coffee
@@ -1,0 +1,44 @@
+DARK = "(prefers-color-scheme: dark)"
+LIGHT = "(prefers-color-scheme: light)"
+
+mqDark = window.matchMedia(DARK)
+mqLight = window.matchMedia(LIGHT)
+
+
+changeColorScheme = (theme) ->
+    zeroframe.cmd "userGetGlobalSettings", [], (user_settings) ->
+        if user_settings.theme != theme
+            user_settings.theme = theme
+            zeroframe.cmd "userSetGlobalSettings", [user_settings]
+
+            location.reload()
+
+        return
+    return
+
+
+displayNotification = ({matches, media}) ->
+    if !matches
+        return
+
+    zeroframe.cmd "wrapperNotification", ["info", "Your system's theme has been changed.<br>Please reload site to use it."]
+    return
+
+
+detectColorScheme = ->
+    if mqDark.matches
+        changeColorScheme("dark")
+    else if mqLight.matches
+        changeColorScheme("light")
+
+    mqDark.addListener(displayNotification)
+    mqLight.addListener(displayNotification)
+
+    return
+
+
+zeroframe.cmd "userGetGlobalSettings", [], (user_settings) ->
+    if user_settings.use_system_theme == true
+        detectColorScheme()
+
+    return

--- a/src/Ui/media/all.js
+++ b/src/Ui/media/all.js
@@ -2046,3 +2046,55 @@ $.extend( $.easing,
   window.zeroframe = new WrapperZeroFrame(window.wrapper);
 
 }).call(this);
+
+
+/* ---- src/Ui/media/ZeroSiteTheme.coffee ---- */
+
+
+(function() {
+  var DARK, LIGHT, changeColorScheme, detectColorScheme, displayNotification, mqDark, mqLight;
+
+  DARK = "(prefers-color-scheme: dark)";
+
+  LIGHT = "(prefers-color-scheme: light)";
+
+  mqDark = window.matchMedia(DARK);
+
+  mqLight = window.matchMedia(LIGHT);
+
+  changeColorScheme = function(theme) {
+    zeroframe.cmd("userGetGlobalSettings", [], function(user_settings) {
+      if (user_settings.theme !== theme) {
+        user_settings.theme = theme;
+        zeroframe.cmd("userSetGlobalSettings", [user_settings]);
+        location.reload();
+      }
+    });
+  };
+
+  displayNotification = function(arg) {
+    var matches, media;
+    matches = arg.matches, media = arg.media;
+    if (!matches) {
+      return;
+    }
+    zeroframe.cmd("wrapperNotification", ["info", "Your system's theme has been changed.<br>Please reload site to use it."]);
+  };
+
+  detectColorScheme = function() {
+    if (mqDark.matches) {
+      changeColorScheme("dark");
+    } else if (mqLight.matches) {
+      changeColorScheme("light");
+    }
+    mqDark.addListener(displayNotification);
+    mqLight.addListener(displayNotification);
+  };
+
+  zeroframe.cmd("userGetGlobalSettings", [], function(user_settings) {
+    if (user_settings.use_system_theme === true) {
+      detectColorScheme();
+    }
+  });
+
+}).call(this);


### PR DESCRIPTION
I created support for the detection of system's theme. This fixes HelloZeroNet/ZeroHello#117.

After this PR is merged, I will also submit PR to ZeroHello to actually change `use_system_theme` setting and configure detection. For that, I need to know the revision of ZeroNet that would have this feature enabled to implement a version check.

This PR adds a new CoffeeScript file that will check if `use_system_theme` setting is true. If it is, it will check the current system's theme. If it is different from current ZeroNet theme, it will set it and reload the page. If the theme is changed when the page is opened, it will display a notification to the user.