### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - : 3.4
   - : 3.5
   - : 3.6
   - : 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - : 3.4
-  - : 3.5
-  - : 3.6
-  - : 3.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 dist: xenial
 services:
  - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,9 @@
 language: python
-
-matrix:
-  include:
-    - python: 3.4
-      dist: trusty
-      sudo: false
-    - python: 3.5
-      dist: trusty
-      sudo: false
-    - python: 3.6
-      dist: trusty
-      sudo: false
-    - python: 3.7
-      dist: xenial
-      sudo: true
-
+python:
+  - : 3.5
+  - : 3.6
+  - : 3.7
+dist: xenial
 services:
  - docker
 install:


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"

Also, removed Python 3.4 because has already reached its end of life:
https://devguide.python.org/devcycle/#end-of-life-branches