### PR TITLE
Handle fileNeed timeout

### DIFF
--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -711,7 +711,7 @@ class UiWebsocket(object):
                 with gevent.Timeout(timeout):
                     self.site.needFile(inner_path, priority=6)
             body = self.site.storage.read(inner_path, "rb")
-        except Exception as err:
+        except (Exception, gevent.Timeout) as err:
             self.log.error("%s fileGet error: %s" % (inner_path, Debug.formatException(err)))
             body = None
 


### PR DESCRIPTION
I'm not sure whether this is a Python3-only bug.

When a timeout happens, `gevent.Timeout` is raised. However, it doesn't inherit from Exception -- so `except Exception` doesn't catch it.