### PR TITLE
ECMAScript modules

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -181,12 +181,12 @@ class UiRequest(object):
 
         if file_name.endswith(".css"):  # Force correct css content type
             content_type = "text/css"
-
+        if file_name.endswith(".js"):  # Force correct javascript content type
+            content_type = "text/javascript"
+        if file_name.endswith(".json"):  # Correct json header
+            content_type = "application/json"
         if not content_type:
-            if file_name.endswith(".json"):  # Correct json header
-                content_type = "application/json"
-            else:
-                content_type = "application/octet-stream"
+            content_type = "application/octet-stream"
 
         return content_type
 
@@ -251,6 +251,8 @@ class UiRequest(object):
         headers["X-Frame-Options"] = "SAMEORIGIN"
         if content_type != "text/html" and self.env.get("HTTP_REFERER") and self.isSameOrigin(self.getReferer(), self.getRequestUrl()):
             headers["Access-Control-Allow-Origin"] = "*"  # Allow load font files from css
+        if content_type == "text/javascript" and not self.env.get("HTTP_REFERER"):
+            headers["Access-Control-Allow-Origin"] = "*"  # Allow loading JavaScript modules in Chrome
 
         if noscript:
             headers["Content-Security-Policy"] = "default-src 'none'; sandbox allow-top-navigation allow-forms; img-src 'self'; font-src 'self'; media-src 'self'; style-src 'self' 'unsafe-inline';"


### PR DESCRIPTION
ECMAScript modules are rather new, but they are supported by Chrome and Firefox already, so I think it's important to support them as well.

This PR makes several changes:

1. All filenames ending with `.js` are forced to have `text/javascript` mimetype (fixes Chrome and Firefox)
2. JavaScript files are allowed to be loaded without Referer header (fixes Chrome)