### PR TITLE
Fix calling start.py to reopen browser

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,10 @@ config.parse(silent=True)  # Plugins need to access the configuration
 if not config.arguments:  # Config parse failed, show the help screen and exit
     config.parse()
 
-config.initLogging()
+try:
+    config.initLogging()
+except Exception:
+    pass
 
 if not os.path.isdir(config.data_dir):
     os.mkdir(config.data_dir)

--- a/src/main.py
+++ b/src/main.py
@@ -20,11 +20,6 @@ config.parse(silent=True)  # Plugins need to access the configuration
 if not config.arguments:  # Config parse failed, show the help screen and exit
     config.parse()
 
-try:
-    config.initLogging()
-except Exception:
-    pass
-
 if not os.path.isdir(config.data_dir):
     os.mkdir(config.data_dir)
     try:
@@ -56,6 +51,8 @@ if config.action == "main":
             except Exception as err:
                 print("Error starting browser: %s" % err)
         sys.exit()
+
+config.initLogging()
 
 
 # Debug dependent configuration


### PR DESCRIPTION
Calling start.py/zeronet.py twice in a row wouldn't work, because ZeroNet would try to logrotate before locking lock.pid.