### PR TITLE
Display a sponsor button in repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://zeronet.io/docs/help_zeronet/donate/


### PR DESCRIPTION
GitHub now supports [sponsorships](https://github.blog/2019-05-23-announcing-github-sponsors-a-new-way-to-contribute-to-open-source/) in the repository.

I created `.github/FUNDING.yml` file which contains a link to ZeroNet donation page. This will now display the sponsor button, but **you need to enable this in repository settings.**

If you also have other supported providers, you can also set up them in this file. You can see [more details](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) about this and details how to enable this.