### PR TITLE
Better error message if private key not stored when assigning

### DIFF
--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -461,7 +461,7 @@ class UiWebsocket(object):
 
         if privatekey == "stored":  # Get privatekey from sites.json
             privatekey = self.user.getSiteData(self.site.address).get("privatekey")
-            self.cmd("notification", ["error", _["Content signing failed"] + "<br><small>Private key for found in sites.json </small>"])
+            self.cmd("notification", ["error", _["Content signing failed"] + "<br><small>Private key not found in sites.json </small>"])
             self.response(to, {"error": "Site sign failed: Private key not stored."})
             self.log.error("Site sign failed: %s: Private key not stored in sites.json" % inner_path)
             return

--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -461,6 +461,10 @@ class UiWebsocket(object):
 
         if privatekey == "stored":  # Get privatekey from sites.json
             privatekey = self.user.getSiteData(self.site.address).get("privatekey")
+            self.cmd("notification", ["error", _["Content signing failed"] + "<br><small>Private key for found in sites.json </small>"])
+            self.response(to, {"error": "Site sign failed: Private key not stored."})
+            self.log.error("Site sign failed: %s: Private key not stored in sites.json" % inner_path)
+            return
         if not privatekey:  # Get privatekey from users.json auth_address
             privatekey = self.user.getAuthPrivatekey(self.site.address)
 


### PR DESCRIPTION
Return a more instructive message in case the privatekey is not found when attempting to sign.

**Current behavior**: It will fetch the the user private key and not the site private key. It will ultimately failed because we are trying to modify a merger-site file.

**Fix** : If failed to get the site private key, an instructive message will be shown to say that the key is not stored. It will no more try to fetch the user private key as a fallback to avoid incoherent error message.

Fix #2022