### PR TITLE
Prevent ZeroNet from running if Python interpreter is optimized

### DIFF
--- a/zeronet.py
+++ b/zeronet.py
@@ -8,8 +8,17 @@ import sys
 def main():
     if sys.version_info.major < 3:
         print("Error: Python 3.x is required")
-        sys.exit(0)
+        sys.exit(1)
 
+    # Test if Python is being ran in optimized mode (-O) because ZN relies on assert
+    try:
+        assert True is False # Intentionally get an AssertionError
+    except AssertionError:
+        pass
+    else:
+        print("Error: ZeroNet cannot be ran in optimized mode")
+        sys.exit(1)
+    
     if "--silent" not in sys.argv:
         print("- Starting ZeroNet...")
 


### PR DESCRIPTION
ZeroNet (and dependencies) rely on assert statements in a few places, notably in [certificate pinning](https://github.com/HelloZeroNet/ZeroNet/blob/eb88dbbec8d88f58c5c4c060a61f74c9074e591e/src/Crypt/CryptConnection.py#L53)

My solution is to use assert to test if the Python interpreter is ran in optimized mode (-O) and exit if so. I doubt optimized mode really speeds up ZeroNet much anyway, so there is nothing of value lost. This just prevents edge case bugs and security issues resulting from the assert statements being ignored.

[See this article](https://hackernoon.com/10-common-security-gotchas-in-python-and-how-to-avoid-them-e19fbe265e03)

I also switched the Python version detection to exit with code 1 because error-exits should be non-zero.

@shortcutme 