### PR TITLE
Fix the order of commands in Dockerfile to make use of the caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM alpine:3.8
 #Base settings
 ENV HOME /root
 
-#Add Zeronet source
-COPY . /root
+COPY requirements.txt /root/requirements.txt
 
 #Install ZeroNet
 RUN apk --no-cache --no-progress add python3 python3-dev gcc libffi-dev musl-dev make tor openssl \
@@ -13,6 +12,8 @@ RUN apk --no-cache --no-progress add python3 python3-dev gcc libffi-dev musl-dev
  && echo "ControlPort 9051" >> /etc/tor/torrc \
  && echo "CookieAuthentication 1" >> /etc/tor/torrc
 
+#Add Zeronet source
+COPY . /root
 VOLUME /root/data
 
 #Control if Tor proxy is started


### PR DESCRIPTION
Fix the order of commands in Dockerfile to make use of the caching of intermediate Docker images.

In py2 version, `COPY . /root` was placed after `RUN apk ...`, so that the result of `RUN apk ...` can be cached by Docker.

In py3 version, the commands were reordered to make the file `/root/requirements.txt` available for `pip install`. That prevents caching, and the docker image every time is rebuild from scrach.

To enable the caching back again, we can `COPY` just the single file `requirements.txt` before running other commands. Since the file is unmodified most of the time, the resulting image can be effectively cached. The other ZeroNet files are copied after doing `RUN apk ...`, as in the previous version.