### PR TITLE
AnnounceShare rework

### DIFF
--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -15,6 +15,10 @@ class TrackerStorage(object):
     def __init__(self):
         self.site_announcer = None
         self.log = logging.getLogger("TrackerStorage")
+
+        self.working_tracker_time_interval = 60 * 60
+        self.tracker_down_time_interval = 60 * 60
+
         self.file_path = "%s/trackers.json" % config.data_dir
         self.load()
         self.time_discover = 0.0
@@ -128,7 +132,7 @@ class TrackerStorage(object):
             error_limit = 30
         error_limit
 
-        if trackers[tracker_address]["num_error"] > error_limit and trackers[tracker_address]["time_success"] < time.time() - 60 * 60:
+        if trackers[tracker_address]["num_error"] > error_limit and trackers[tracker_address]["time_success"] < time.time() - self.tracker_down_time_interval:
             self.log.debug("Tracker %s looks down, removing." % tracker_address)
             del trackers[tracker_address]
 
@@ -138,7 +142,7 @@ class TrackerStorage(object):
         if not tracker:
             return False
 
-        if tracker["time_success"] > time.time() - 60 * 60:
+        if tracker["time_success"] > time.time() - self.working_tracker_time_interval:
             return True
 
         return False

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -18,6 +18,7 @@ class TrackerStorage(object):
 
         self.working_tracker_time_interval = 60 * 60
         self.tracker_down_time_interval = 60 * 60
+        self.tracker_discover_time_interval = 5 * 60
 
         self.file_path = "%s/trackers.json" % config.data_dir
         self.load()
@@ -272,7 +273,7 @@ if "tracker_storage" not in locals():
 class SiteAnnouncerPlugin(object):
     def getTrackers(self):
         tracker_storage.setSiteAnnouncer(self)
-        if tracker_storage.time_discover < time.time() - 5 * 60:
+        if tracker_storage.time_discover < time.time() - tracker_storage.tracker_discover_time_interval:
             tracker_storage.time_discover = time.time()
             gevent.spawn(tracker_storage.discoverTrackers, self.site.getConnectedPeers())
         trackers = super(SiteAnnouncerPlugin, self).getTrackers()

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -63,7 +63,7 @@ class TrackerStorage(object):
 
         protocol = address_parts["protocol"]
         if protocol == "https":
-            protocol == "http"
+            protocol = "http"
 
         return protocol
 

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -232,8 +232,11 @@ class TrackerStorage(object):
         return True
 
     def discoverTrackers(self, peers):
-        if not self.enoughWorkingTrackers(type="shared"):
+        if self.enoughWorkingTrackers(type="shared"):
             return False
+
+        self.log.debug("Discovering trackers from %s peers..." % len(peers))
+
         s = time.time()
         num_success = 0
         for peer in peers:

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -26,7 +26,7 @@ class TrackerStorage(object):
         if not tracker_address.startswith("zero://"):
             return False
 
-        trackers = self.getTrackers()
+        trackers = self.getTrackers(type)
         added = False
         if tracker_address not in trackers:
             trackers[tracker_address] = {

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -73,14 +73,14 @@ class TrackerStorage(object):
 
         supported_trackers = self.site_announcer.getSupportedTrackers()
 
-        protocols = {}
+        protocols = set()
         for tracker_address in supported_trackers:
             protocol = self.getNormalizedTrackerProtocol(tracker_address)
             if not protocol:
                 continue
-            protocols[protocol] = True
+            protocols.add(protocol)
 
-        protocols = list(protocols.keys())
+        protocols = list(protocols)
 
         self.log.debug("Supported tracker protocols: %s" % protocols)
 

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -147,11 +147,16 @@ class TrackerStorage(object):
             # There may be network connectivity issues.
             return
 
-        if len(self.getWorkingTrackers()) >= config.working_shared_trackers_limit:
-            error_limit = 5
-        else:
-            error_limit = 30
-        error_limit
+        protocol = self.getNormalizedTrackerProtocol(tracker_address) or ""
+
+        nr_working_trackers_for_protocol = len(self.getTrackersPerProtocol(working_only=True).get(protocol, []))
+        nr_working_trackers = len(self.getWorkingTrackers())
+
+        error_limit = 30
+        if nr_working_trackers_for_protocol >= config.working_shared_trackers_limit_per_protocol:
+            error_limit = 10
+            if nr_working_trackers >= config.working_shared_trackers_limit:
+                error_limit = 5
 
         if trackers[tracker_address]["num_error"] > error_limit and trackers[tracker_address]["time_success"] < time.time() - self.tracker_down_time_interval:
             self.log.debug("Tracker %s looks down, removing." % tracker_address)

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -1,3 +1,4 @@
+import random
 import time
 import os
 import logging
@@ -260,6 +261,8 @@ class TrackerStorage(object):
                 continue
 
             num_success += 1
+
+            random.shuffle(res["trackers"])
             for tracker_address in res["trackers"]:
                 if type(tracker_address) is bytes:  # Backward compatibilitys
                     tracker_address = tracker_address.decode("utf8")
@@ -310,6 +313,7 @@ class SiteAnnouncerPlugin(object):
 class FileRequestPlugin(object):
     def actionGetTrackers(self, params):
         shared_trackers = list(tracker_storage.getWorkingTrackers("shared").keys())
+        random.shuffle(shared_trackers)
         self.response({"trackers": shared_trackers})
 
 

--- a/plugins/AnnounceShare/AnnounceSharePlugin.py
+++ b/plugins/AnnounceShare/AnnounceSharePlugin.py
@@ -317,7 +317,7 @@ class FileServerPlugin(object):
 class ConfigPlugin(object):
     def createArguments(self):
         group = self.parser.add_argument_group("AnnounceShare plugin")
-        group.add_argument('--working_shared_trackers_limit', help='Stop discovering new shared trackers after this number of shared trackers reached (total)', default=5, type=int, metavar='limit')
-        group.add_argument('--working_shared_trackers_limit_per_protocol', help='Stop discovering new shared trackers after this number of shared trackers reached per each supported protocol', default=3, type=int, metavar='limit')
+        group.add_argument('--working_shared_trackers_limit', help='Stop discovering new shared trackers after this number of shared trackers reached (total)', default=10, type=int, metavar='limit')
+        group.add_argument('--working_shared_trackers_limit_per_protocol', help='Stop discovering new shared trackers after this number of shared trackers reached per each supported protocol', default=5, type=int, metavar='limit')
 
         return super(ConfigPlugin, self).createArguments()


### PR DESCRIPTION
* Allow sharing trackers of any supported protocols, not just `zero://`. (Right now it includes BitTorrent over HTTP(S) and BitTorrent over UDP.)
  * The supported protocols are autodetected, not hardcoded, so the modification of the plugin is not required in case of implementation of new protocols.
* Working trackers are now counted on per protocol basis. The plugin tries to maintain the up-to-date list of functional trackers for each available protocol.
* Be more conservative on removal trackers from the list. Don't delete trackers on errors if no successful connections have been established recently, in the case of the network connectivity issues.
* Other small code refactorings, such as replacing magic constants with meaningful names.

The updated plugin is meant to be used as a general-purpose tracker exchange facility, not limited to sharing locally running autodetected `Boostrapper`s.