### PR TITLE
Guess content type correctly

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -174,7 +174,7 @@ class UiRequest(object):
     # Get mime by filename
     def getContentType(self, file_name):
         file_name = file_name.lower()
-        ext = file_name.split(".", 1)[-1]
+        ext = file_name.rsplit(".", 1)[-1]
 
         if ext == "css":  # Force correct css content type
             content_type = "text/css"


### PR DESCRIPTION
Fix e.g. vue.min.js being reported as text/plain instead of text/javascript.