### PR TITLE
Fix infinite reloading when system theme changes

### DIFF
--- a/src/Ui/media/ZeroSiteTheme.coffee
+++ b/src/Ui/media/ZeroSiteTheme.coffee
@@ -9,10 +9,10 @@ changeColorScheme = (theme) ->
     zeroframe.cmd "userGetGlobalSettings", [], (user_settings) ->
         if user_settings.theme != theme
             user_settings.theme = theme
-            zeroframe.cmd "userSetGlobalSettings", [user_settings]
-
-            location.reload()
-
+            zeroframe.cmd "userSetGlobalSettings", [user_settings], (status) ->
+                if status == "ok"
+                    location.reload()
+                return
         return
     return
 
@@ -21,7 +21,12 @@ displayNotification = ({matches, media}) ->
     if !matches
         return
 
-    zeroframe.cmd "wrapperNotification", ["info", "Your system's theme has been changed.<br>Please reload site to use it."]
+    zeroframe.cmd "siteInfo", [], (site_info) ->
+        if "ADMIN" in site_info.settings.permissions
+            zeroframe.cmd "wrapperNotification", ["info", "Your system's theme has been changed.<br>Please reload site to use it."]
+        else
+            zeroframe.cmd "wrapperNotification", ["info", "Your system's theme has been changed.<br>Please open ZeroHello to use it."]
+        return
     return
 
 

--- a/src/Ui/media/all.js
+++ b/src/Ui/media/all.js
@@ -1981,7 +1981,6 @@ $.extend( $.easing,
 
 }).call(this);
 
-
 /* ---- src/Ui/media/WrapperZeroFrame.coffee ---- */
 
 
@@ -2037,7 +2036,8 @@ $.extend( $.easing,
 
 
 (function() {
-  var DARK, LIGHT, changeColorScheme, detectColorScheme, displayNotification, mqDark, mqLight;
+  var DARK, LIGHT, changeColorScheme, detectColorScheme, displayNotification, mqDark, mqLight,
+    indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   DARK = "(prefers-color-scheme: dark)";
 
@@ -2051,8 +2051,11 @@ $.extend( $.easing,
     zeroframe.cmd("userGetGlobalSettings", [], function(user_settings) {
       if (user_settings.theme !== theme) {
         user_settings.theme = theme;
-        zeroframe.cmd("userSetGlobalSettings", [user_settings]);
-        location.reload();
+        zeroframe.cmd("userSetGlobalSettings", [user_settings], function(status) {
+          if (status === "ok") {
+            location.reload();
+          }
+        });
       }
     });
   };
@@ -2063,7 +2066,13 @@ $.extend( $.easing,
     if (!matches) {
       return;
     }
-    zeroframe.cmd("wrapperNotification", ["info", "Your system's theme has been changed.<br>Please reload site to use it."]);
+    zeroframe.cmd("siteInfo", [], function(site_info) {
+      if (indexOf.call(site_info.settings.permissions, "ADMIN") >= 0) {
+        zeroframe.cmd("wrapperNotification", ["info", "Your system's theme has been changed.<br>Please reload site to use it."]);
+      } else {
+        zeroframe.cmd("wrapperNotification", ["info", "Your system's theme has been changed.<br>Please open ZeroHello to use it."]);
+      }
+    });
   };
 
   detectColorScheme = function() {


### PR DESCRIPTION
This fixes problem with infinite reloading which was introduced with my #1999.

When system theme changes, the wrapper will send a notification to the user to reload the page. When a page is reloaded, it checks if the current user's theme is equal to the system's theme. If it's not, it should change the user's theme to the system's theme and reload the page again.

But the problem is that the user's global settings can only be changed on sites with ˙ADMIN` permission. This means that if the user reloads different page than ZeroHello, it will still try to change settings but fail. But even if it failed, the page will reload. This will result in the infinitive loop of reloads.

I added checks for `ADMIN` permission. If the site doesn't have it, the user is notified to visit ZeroHello to use the new theme. And if the user reloads the page, it will still try to change settings, but reload only change is successful.