### PR TITLE
Fix a websocket connection issue when running in the proxy mode

### DIFF
--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -25,6 +25,12 @@ class UiWSGIHandler(WSGIHandler):
         self.args = args
         self.kwargs = kwargs
 
+    def finalize_headers(self):
+        # Send no additional headers in response to the CONNECT method
+        if self.environ['REQUEST_METHOD'] == "CONNECT":
+            return
+        super(UiWSGIHandler, self).finalize_headers()
+
     def run_application(self):
         if "HTTP_UPGRADE" in self.environ:  # Websocket request
             try:
@@ -50,7 +56,6 @@ class UiWSGIHandler(WSGIHandler):
         self.server.sockets[self.client_address] = self.socket
         super(UiWSGIHandler, self).handle()
         del self.server.sockets[self.client_address]
-
 
 class UiServer:
 

--- a/src/Ui/media/Wrapper.coffee
+++ b/src/Ui/media/Wrapper.coffee
@@ -692,7 +692,7 @@ class Wrapper
 	log: (args...) ->
 		console.log "[Wrapper]", args...
 
-origin = window.server_url or window.location.href.replace(/(\:\/\/.*?)\/.*/, "$1")
+origin = window.location.href.replace(/(\:\/\/.*?)\/.*/, "$1")
 
 if origin.indexOf("https:") == 0
 	proto = { ws: 'wss', http: 'https' }

--- a/src/Ui/media/all.js
+++ b/src/Ui/media/all.js
@@ -1961,7 +1961,7 @@ $.extend( $.easing,
 
   })();
 
-  origin = window.server_url || window.location.href.replace(/(\:\/\/.*?)\/.*/, "$1");
+  origin = window.location.href.replace(/(\:\/\/.*?)\/.*/, "$1");
 
   if (origin.indexOf("https:") === 0) {
     proto = {

--- a/src/Ui/template/wrapper.html
+++ b/src/Ui/template/wrapper.html
@@ -83,7 +83,6 @@ postmessage_nonce_security = {postmessage_nonce_security}
 file_inner_path = "{file_inner_path}"
 permissions = {permissions}
 show_loadingscreen = {show_loadingscreen}
-server_url = '{server_url}'
 script_nonce = '{script_nonce}'
 
 if (typeof WebSocket === "undefined") {


### PR DESCRIPTION
Steps to reproduce:

1. Run Zeronet with --ui_trans_proxy in a docker container or other isolated environment.
2. Set 127.0.0.1:43110 as a HTTP Proxy in a browser.
3. Navigate to http://talk.zeronetwork.bit/
4. The site stops loading, since the websocket connection isn't functional.

The bug consists of 2 related issues:

1. Connect to the proper address.

   When running in the proxy mode, Zeronet sends its env["SERVER_NAME"] and env["SERVER_PORT"] as the websocket destination address in the wrappper HTML code (variable `server_url`). That looks wrong for me, since the values of those variables have nothing to do with the actual address accessible by the browser. ZeroNet can run in a container, the connection also can be tunneled over SSH and so on. In all those cases, the internal SERVER_NAME makes no sense as the destination at all.

   The code for sending and handling `server_url` is deleted. The browser should connect to the websocket in the same way as it connects to the ZeroNet UI in general.

2. Send the proper response for CONNECT requests.

   A browser tries to connect to the correct address, but it still fails. A browser, when connecting via a HTTP proxy to a webdocket, uses the [HTTP tunneling protocol](https://en.wikipedia.org/wiki/HTTP_tunnel), and ZeroNet lacks support for it. To fix this, it's enoght to send the "200 OK" response on the CONNECT method request.