### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Decentralized websites using Bitcoin crypto and the BitTorrent network - https:/
 
 Fetch and extract the source:
 
-    wget https://github.com/HelloZeroNet/ZeroNet/archive/py3/ZeroNet-py3.tar.gz
+    wget --no-check-certificate https://github.com/HelloZeroNet/ZeroNet/archive/py3/ZeroNet-py3.tar.gz
     tar xvpfz ZeroNet-py3.tar.gz
     cd ZeroNet-py3
 


### PR DESCRIPTION
Without skipping certificate check, an "wget" error may be shown on Debian 9 ARM:

ERROR: The certificate of 'github.com' is not trusted.
ERROR: The certificate of 'github.com' hasn't got a known issuer.