### PR TITLE
Save content.json of site even if limit size is reached

### DIFF
--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -859,14 +859,15 @@ class ContentManager(object):
             raise VerifyError("Wrong inner_path: %s" % content["inner_path"])
 
         # Check total site size limit
-        if site_size > site_size_limit:
-            if inner_path == "content.json" and self.site.settings["size"] == 0:
-                # First content.json download, save site size to display warning
-                self.site.settings["size"] = site_size
-            task = self.site.worker_manager.findTask(inner_path)
-            if task:  # Dont try to download from other peers
-                self.site.worker_manager.failTask(task)
-            raise VerifyError("Content too large %sB > %sB, aborting task..." % (site_size, site_size_limit))
+        # Should not be checked here
+        #if site_size > site_size_limit:
+        #    if inner_path == "content.json" and self.site.settings["size"] == 0:
+        #        # First content.json download, save site size to display warning
+        #        self.site.settings["size"] = site_size
+        #    task = self.site.worker_manager.findTask(inner_path)
+        #    if task:  # Dont try to download from other peers
+        #        self.site.worker_manager.failTask(task)
+        #    raise VerifyError("Content too large %sB > %sB, aborting task..." % (site_size, site_size_limit))
 
         # Verify valid filenames
         for file_relative_path in list(content.get("files", {}).keys()) + list(content.get("files_optional", {}).keys()):

--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -869,6 +869,17 @@ class ContentManager(object):
         #        self.site.worker_manager.failTask(task)
         #    raise VerifyError("Content too large %sB > %sB, aborting task..." % (site_size, site_size_limit))
 
+        # If our content.json file bigger than the size limit throw error
+        if inner_path == "content.json":
+            content_size_file = len(json.dumps(content, indent=1))
+            if content_size_file > site_size_limit:
+                # Save site size to display warning
+                self.site.settings["size"] = site_size
+                task = self.site.worker_manager.findTask(inner_path)
+                if task:  # Dont try to download from other peers
+                    self.site.worker_manager.failTask(task)
+                raise VerifyError("Content too large %s B > %s B, aborting task..." % (site_size, site_size_limit))
+
         # Verify valid filenames
         for file_relative_path in list(content.get("files", {}).keys()) + list(content.get("files_optional", {}).keys()):
             if not self.isValidRelativePath(file_relative_path):

--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -858,17 +858,6 @@ class ContentManager(object):
         if content.get("inner_path") and content["inner_path"] != inner_path:
             raise VerifyError("Wrong inner_path: %s" % content["inner_path"])
 
-        # Check total site size limit
-        # Should not be checked here
-        #if site_size > site_size_limit:
-        #    if inner_path == "content.json" and self.site.settings["size"] == 0:
-        #        # First content.json download, save site size to display warning
-        #        self.site.settings["size"] = site_size
-        #    task = self.site.worker_manager.findTask(inner_path)
-        #    if task:  # Dont try to download from other peers
-        #        self.site.worker_manager.failTask(task)
-        #    raise VerifyError("Content too large %sB > %sB, aborting task..." % (site_size, site_size_limit))
-
         # If our content.json file bigger than the size limit throw error
         if inner_path == "content.json":
             content_size_file = len(json.dumps(content, indent=1))

--- a/src/Test/TestSiteDownload.py
+++ b/src/Test/TestSiteDownload.py
@@ -422,7 +422,7 @@ class TestSiteDownload:
         client.sites[site_temp.address] = site_temp
         site_temp.connection_server = client
 
-        # Connect peers
+        # Connect peersself, file_server, site, site_temp
         site_temp.addPeer(file_server.ip, 1544)
 
         # Download site from site to site_temp
@@ -460,3 +460,42 @@ class TestSiteDownload:
             assert len(file_requests) == 1
 
         assert site_temp.storage.open("data/data.json").read() == data_new
+        assert site_temp.storage.open("content.json").read() == site.storage.open("content.json").read()
+
+    # Test what happened if the content.json of the site is bigger than the site limit
+    def testHugeContentSiteUpdate(self, file_server, site, site_temp):
+        # Init source server
+        site.connection_server = file_server
+        file_server.sites[site.address] = site
+
+        # Init client server
+        client = FileServer(file_server.ip, 1545)
+        client.sites[site_temp.address] = site_temp
+        site_temp.connection_server = client
+
+        # Connect peersself, file_server, site, site_temp
+        site_temp.addPeer(file_server.ip, 1544)
+
+        # Download site from site to site_temp
+        site_temp.download(blind_includes=True).join(timeout=5)
+
+        content_json = site.storage.loadJson("content.json")
+        content_json["description"] = "PartirUnJour" * 1024 * 1024
+        site.storage.writeJson("content.json", content_json)
+        site.content_manager.loadContent("content.json", force=True)
+
+        # Make sure we have 2 differents content.json
+        assert site_temp.storage.open("content.json").read() != site.storage.open("content.json").read()
+
+        # Generate diff
+        diffs = site.content_manager.getDiffs("content.json")
+
+        # Publish with patch
+        site.log.info("Publish new content.json bigger than 10MB")
+        with Spy.Spy(FileRequest, "route") as requests:
+            site.content_manager.sign("content.json", privatekey="5KUh3PvNm5HUWoCfSUfcYvfQ2g3PrRNJWr6Q9eqdBGu23mtMntv")
+            assert site.storage.getSize("content.json") > 10 * 1024 * 1024  # verify it over 10MB
+            site.publish(diffs=diffs)
+            site_temp.download(blind_includes=True).join(timeout=5)
+            file_requests = [request for request in requests if request[1] in ("getFile", "streamFile")]
+            assert len(file_requests) == 1

--- a/src/Test/TestSiteDownload.py
+++ b/src/Test/TestSiteDownload.py
@@ -479,10 +479,14 @@ class TestSiteDownload:
         # Download site from site to site_temp
         site_temp.download(blind_includes=True).join(timeout=5)
 
+        # Raise limit size to 20MB on site so it can be signed
+        site.settings["size_limit"] = int(20 * 1024 *1024)
+        site.saveSettings()
+
         content_json = site.storage.loadJson("content.json")
         content_json["description"] = "PartirUnJour" * 1024 * 1024
         site.storage.writeJson("content.json", content_json)
-        site.content_manager.loadContent("content.json", force=True)
+        changed, deleted = site.content_manager.loadContent("content.json", force=True)
 
         # Make sure we have 2 differents content.json
         assert site_temp.storage.open("content.json").read() != site.storage.open("content.json").read()
@@ -498,5 +502,5 @@ class TestSiteDownload:
             site.publish(diffs=diffs)
             site_temp.download(blind_includes=True).join(timeout=5)
 
-        assert site_temp.getSize("content.json") < site_temp.getSizeLimit() * 1024 * 1024
-        #assert site_temp.storage.open("content.json").read() != site.storage.open("content.json").read()
+        assert site_temp.storage.getSize("content.json") < site_temp.getSizeLimit() * 1024 * 1024
+        assert site_temp.storage.open("content.json").read() != site.storage.open("content.json").read()

--- a/src/Test/TestSiteDownload.py
+++ b/src/Test/TestSiteDownload.py
@@ -497,5 +497,6 @@ class TestSiteDownload:
             assert site.storage.getSize("content.json") > 10 * 1024 * 1024  # verify it over 10MB
             site.publish(diffs=diffs)
             site_temp.download(blind_includes=True).join(timeout=5)
-            file_requests = [request for request in requests if request[1] in ("getFile", "streamFile")]
-            assert len(file_requests) == 1
+
+        assert site_temp.getSize("content.json") < site_temp.getSizeLimit() * 1024 * 1024
+        #assert site_temp.storage.open("content.json").read() != site.storage.open("content.json").read()


### PR DESCRIPTION
fix #2107; Still save the content.json received even if site size limit is reached but dont download files; Allow better distribution of latest version of content.json