### PR TITLE
Add response to some commands

### DIFF
--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -362,6 +362,8 @@ class UiWebsocket(object):
             if channel not in self.channels:
                 self.channels.append(channel)
 
+        self.response(to, "ok")
+
     # Server variables
     def actionServerInfo(self, to):
         back = self.formatServerInfo()
@@ -877,6 +879,8 @@ class UiWebsocket(object):
         for site in list(self.server.sites.values()):  # Add websocket to every channel
             if self not in site.websockets:
                 site.websockets.append(self)
+
+        self.response(to, "ok")
 
     # Update site content.json
     def actionSiteUpdate(self, to, address, check_files=False, since=None, announce=False):


### PR DESCRIPTION
Add response to some ZeroFrame commands. If this is not used, and the command is called with `await zeroframe.cmdp`, it will hang forever because response won't be sent.