### PR TITLE
Fix preferring CLI argument over zeronet.conf

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -420,7 +420,7 @@ class Config(object):
                         key = section + "_" + key
 
                     if key == "open_browser":  # Prefer config file value over cli argument
-                        if "--%s" % key in argv:
+                        while "--%s" % key in argv:
                             pos = argv.index("--open_browser")
                             del argv[pos:pos + 2]
 


### PR DESCRIPTION
Fix using open_browser from CLI arguments in case there are several `--open_browser` arguments, which often happens after restarts.