### PR TITLE
Allow all valid filenames to be added to content.json

### DIFF
--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -600,10 +600,10 @@ class ContentManager(object):
         elif len(relative_path) > 255:
             return False
         else:
-            return re.match(r"^[^\x00-\x1F\x22\x2A\x3A\x3C\x3E\x3F\x5C\x7C]+$", relative_path)
+            return re.match(r"^[^\x00-\x1F\"*:<>?\\|]+$", relative_path)
 
     def sanitizePath(self, inner_path):
-        return re.sub("[\x00-\x1F\x22\x2A\x3A\x3C\x3E\x3F\x5C\x7C]", "", inner_path)
+        return re.sub("[\x00-\x1F\"*:<>?\\|]", "", inner_path)
 
     # Hash files in directory
     def hashFiles(self, dir_inner_path, ignore_pattern=None, optional_pattern=None):

--- a/src/Content/ContentManager.py
+++ b/src/Content/ContentManager.py
@@ -600,10 +600,10 @@ class ContentManager(object):
         elif len(relative_path) > 255:
             return False
         else:
-            return re.match(r"^[a-z\[\]\(\) A-Z0-9~_@=\.\+-/]+$", relative_path)
+            return re.match(r"^[^\x00-\x1F\x22\x2A\x3A\x3C\x3E\x3F\x5C\x7C]+$", relative_path)
 
     def sanitizePath(self, inner_path):
-        return re.sub("[^a-z\[\]\(\) A-Z0-9_@=\.\+-/]", "", inner_path)
+        return re.sub("[\x00-\x1F\x22\x2A\x3A\x3C\x3E\x3F\x5C\x7C]", "", inner_path)
 
     # Hash files in directory
     def hashFiles(self, dir_inner_path, ignore_pattern=None, optional_pattern=None):

--- a/src/Test/TestContent.py
+++ b/src/Test/TestContent.py
@@ -246,3 +246,8 @@ class TestContent:
             with site.storage.open("data/users/1C5sgvWaSgfaTpV5kjBCnCiKtENNMYo69q/content.json") as data:
                 site.content_manager.verifyFile("data/users/1C5sgvWaSgfaTpV5kjBCnCiKtENNMYo69q/content.json", data, ignore_same=False)
         assert "Potentially unsafe" in str(err.value)
+
+
+    @pytest.mark.parametrize("filename", ["test.txt", "test/!@#$%^&().txt", "ÜøßÂŒƂÆÇ.txt"])
+    def testPathValidation(self, site, filename):
+        assert site.content_manager.isValidRelativePath(filename)

--- a/src/Test/TestContent.py
+++ b/src/Test/TestContent.py
@@ -248,6 +248,10 @@ class TestContent:
         assert "Potentially unsafe" in str(err.value)
 
 
-    @pytest.mark.parametrize("filename", ["test.txt", "test/!@#$%^&().txt", "ÜøßÂŒƂÆÇ.txt"])
-    def testPathValidation(self, site, filename):
-        assert site.content_manager.isValidRelativePath(filename)
+    def testPathValidation(self, site):
+        assert site.content_manager.isValidRelativePath("test.txt")
+        assert site.content_manager.isValidRelativePath("test/!@#$%^&().txt")
+        assert site.content_manager.isValidRelativePath("ÜøßÂŒƂÆÇ.txt")
+        assert site.content_manager.isValidRelativePath("тест.текст")
+        assert site.content_manager.isValidRelativePath("𝐮𝐧𝐢𝐜𝐨𝐝𝐞𝑖𝑠𝒂𝒘𝒆𝒔𝒐𝒎𝒆")
+


### PR DESCRIPTION
Fix #2136 by allowing all valid filenames to be added to content.json when a site is published.

I basically used the new regex expressions that the creator of the issue suggested, modified to allow files in subdirectories to also be added to content.json.