### PR TITLE
Add GitLab CI/CD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .*
 !/.gitignore
 !/.travis.yml
+!/.gitlab-ci.yml
 
 # Temporary files
 *.bak

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,13 +11,16 @@ test:
   script:
     - pip list
     - openssl version -a
-    - python -m pytest -x plugins/CryptMessage/Test
-    - python -m pytest -x plugins/Bigfile/Test
-    - python -m pytest -x plugins/AnnounceLocal/Test
-    - python -m pytest -x plugins/OptionalManager/Test
-    - python -m pytest src/Test --cov=src --cov-config src/Test/coverage.ini
-    - mv plugins/disabled-Multiuser plugins/Multiuser && python -m pytest -x plugins/Multiuser/Test
-    - mv plugins/disabled-Bootstrapper plugins/Bootstrapper && python -m pytest -x plugins/Bootstrapper/Test
+    - PYTEST_ADDOPTS="--color=yes"
+    - python -m pytest -x plugins/CryptMessage/Test --color=yes
+    - python -m pytest -x plugins/Bigfile/Test --color=yes
+    - python -m pytest -x plugins/AnnounceLocal/Test --color=yes
+    - python -m pytest -x plugins/OptionalManager/Test --color=yes
+    - python -m pytest src/Test --cov=src --cov-config src/Test/coverage.ini --color=yes
+    - mv plugins/disabled-Multiuser plugins/Multiuser
+    - python -m pytest -x plugins/Multiuser/Test --color=yes
+    - mv plugins/disabled-Bootstrapper plugins/Bootstrapper
+    - python -m pytest -x plugins/Bootstrapper/Test --color=yes
     - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --exclude=src/lib/pybitcointools/
     - codecov
     - coveralls --rcfile=src/Test/coverage.ini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,6 @@ test:
   script:
     - pip list
     - openssl version -a
-    - PYTEST_ADDOPTS="--color=yes"
     - python -m pytest -x plugins/CryptMessage/Test --color=yes
     - python -m pytest -x plugins/Bigfile/Test --color=yes
     - python -m pytest -x plugins/AnnounceLocal/Test --color=yes

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,23 @@
+stages:
+  - test
+
+test:
+  image: python:3.7.0b5
+  stage: test
+  before_script:
+    - pip install --upgrade pip wheel
+    - pip install --upgrade codecov coveralls flake8 mock pytest==4.6.3 pytest-cov selenium
+    - pip install --upgrade -r requirements.txt
+  script:
+    - pip list
+    - openssl version -a
+    - python -m pytest -x plugins/CryptMessage/Test
+    - python -m pytest -x plugins/Bigfile/Test
+    - python -m pytest -x plugins/AnnounceLocal/Test
+    - python -m pytest -x plugins/OptionalManager/Test
+    - python -m pytest src/Test --cov=src --cov-config src/Test/coverage.ini
+    - mv plugins/disabled-Multiuser plugins/Multiuser && python -m pytest -x plugins/Multiuser/Test
+    - mv plugins/disabled-Bootstrapper plugins/Bootstrapper && python -m pytest -x plugins/Bootstrapper/Test
+    - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --exclude=src/lib/pybitcointools/
+    - codecov
+    - coveralls --rcfile=src/Test/coverage.ini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,7 @@
 stages:
   - test
 
-test:
-  image: python:3.7.0b5
+.test_template: &test_template
   stage: test
   before_script:
     - pip install --upgrade pip wheel
@@ -21,3 +20,19 @@ test:
     - mv plugins/disabled-Bootstrapper plugins/Bootstrapper
     - python -m pytest -x plugins/Bootstrapper/Test --color=yes
     - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --exclude=src/lib/pybitcointools/
+
+test:py3.5:
+  image: python:3.5.7
+  <<: *test_template
+
+test:py3.6:
+  image: python:3.6.9
+  <<: *test_template
+
+test:py3.7:
+  image: python:3.7.4
+  <<: *test_template
+
+test:py3.8:
+  image: python:3.8.0b3
+  <<: *test_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,8 @@ stages:
   stage: test
   before_script:
     - pip install --upgrade pip wheel
+    # Selenium and requests can't be installed without a requests hint on Python 3.4
+    - pip install --upgrade requests>=2.22.0
     - pip install --upgrade codecov coveralls flake8 mock pytest==4.6.3 pytest-cov selenium
     - pip install --upgrade -r requirements.txt
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,10 @@ stages:
     - python -m pytest -x plugins/Bootstrapper/Test --color=yes
     - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --exclude=src/lib/pybitcointools/
 
+test:py3.4:
+  image: python:3.4.3
+  <<: *test_template
+
 test:py3.5:
   image: python:3.5.7
   <<: *test_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,5 +21,3 @@ test:
     - mv plugins/disabled-Bootstrapper plugins/Bootstrapper
     - python -m pytest -x plugins/Bootstrapper/Test --color=yes
     - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics --exclude=src/lib/pybitcointools/
-    - codecov
-    - coveralls --rcfile=src/Test/coverage.ini

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,11 @@ test:py3.6:
   image: python:3.6.9
   <<: *test_template
 
-test:py3.7:
+test:py3.7-openssl1.1.0:
+  image: python:3.7.0b5
+  <<: *test_template
+
+test:py3.7-openssl1.1.1:
   image: python:3.7.4
   <<: *test_template
 

--- a/plugins/disabled-Bootstrapper/Test/pytest.ini
+++ b/plugins/disabled-Bootstrapper/Test/pytest.ini
@@ -2,4 +2,5 @@
 python_files = Test*.py
 addopts = -rsxX -v --durations=6
 markers =
+    slow: mark a tests as slow.
     webtest: mark a test as a webtest.

--- a/src/Crypt/CryptBitcoin.py
+++ b/src/Crypt/CryptBitcoin.py
@@ -26,9 +26,16 @@ def loadLib(lib_name):
         import bitcoin.core.key
         import bitcoin.wallet
 
+        try:
+            # OpenSSL 1.1.0
+            ssl_version = bitcoin.core.key._ssl.SSLeay()
+        except AttributeError:
+            # OpenSSL 1.1.1+
+            ssl_version = bitcoin.core.key._ssl.OpenSSL()
+
         logging.info(
             "OpenSSL loaded: %s, version: %.9X in %.3fs" %
-            (bitcoin.core.key._ssl, bitcoin.core.key._ssl.SSLeay(), time.time() - s)
+            (bitcoin.core.key._ssl, ssl_version, time.time() - s)
         )
 
 

--- a/src/Crypt/CryptBitcoin.py
+++ b/src/Crypt/CryptBitcoin.py
@@ -31,7 +31,7 @@ def loadLib(lib_name):
             ssl_version = bitcoin.core.key._ssl.SSLeay()
         except AttributeError:
             # OpenSSL 1.1.1+
-            ssl_version = bitcoin.core.key._ssl.OpenSSL()
+            ssl_version = bitcoin.core.key._ssl.OpenSSL_version_num()
 
         logging.info(
             "OpenSSL loaded: %s, version: %.9X in %.3fs" %

--- a/src/Test/conftest.py
+++ b/src/Test/conftest.py
@@ -109,13 +109,14 @@ from Debug import Debug
 def cleanup():
     Db.dbCloseAll()
     for dir_path in [config.data_dir, config.data_dir + "-temp"]:
-        for file_name in os.listdir(dir_path):
-            ext = file_name.rsplit(".", 1)[-1]
-            if ext not in ["csr", "pem", "srl", "db", "json", "tmp"]:
-                continue
-            file_path = dir_path + "/" + file_name
-            if os.path.isfile(file_path):
-                os.unlink(file_path)
+        if os.path.isdir(dir_path):
+            for file_name in os.listdir(dir_path):
+                ext = file_name.rsplit(".", 1)[-1]
+                if ext not in ["csr", "pem", "srl", "db", "json", "tmp"]:
+                    continue
+                file_path = dir_path + "/" + file_name
+                if os.path.isfile(file_path):
+                    os.unlink(file_path)
 
 atexit.register(cleanup)
 

--- a/src/Test/pytest.ini
+++ b/src/Test/pytest.ini
@@ -2,4 +2,5 @@
 python_files = Test*.py
 addopts = -rsxX -v --durations=6
 markers =
+    slow: mark a tests as slow.
     webtest: mark a test as a webtest.


### PR DESCRIPTION
This PR adds GitLab CI/CD support. `codecov` and `coveralls` aren't used (yet).

Some people might find this PR weird: ZeroNet is hosted on GitHub, why is it *GitLab* CI then? One of the reasons is that ZeroNet has [a GitLab repository](https://gitlab.com/HelloZeroNet/ZeroNet) as a mirror. Another reason is more of "why not": there are Dockerfile and Vargantfile in this repository already, so adding another file should not be an issue. The third reason is something I'm currently discussing with nofish privately.

This is how GitLab CI looks:

![image](https://user-images.githubusercontent.com/16370781/63271347-7756dc00-c289-11e9-937e-839454b72b96.png)

![image](https://user-images.githubusercontent.com/16370781/63271385-8dfd3300-c289-11e9-8033-5712fabb0456.png)

![image](https://user-images.githubusercontent.com/16370781/63271420-a1a89980-c289-11e9-8aad-4b3c4aa6f2f1.png)

![image](https://user-images.githubusercontent.com/16370781/63271453-b38a3c80-c289-11e9-9c06-a85a12d2965a.png)
