### PR TITLE
Add --merge_media config option

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -206,6 +206,7 @@ class Config(object):
         self.parser.add_argument('--debug', help='Debug mode', action='store_true')
         self.parser.add_argument('--silent', help='Only log errors to terminal output', action='store_true')
         self.parser.add_argument('--debug_socket', help='Debug socket connections', action='store_true')
+        self.parser.add_argument('--merge_media', help='Merge all.js and all.css', action='store_true')
 
         self.parser.add_argument('--batch', help="Batch mode (No interactive input for commands)", action='store_true')
 

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -551,7 +551,7 @@ class UiRequest(object):
         address = path_parts["address"]
         file_path = "%s/%s/%s" % (config.data_dir, address, path_parts["inner_path"])
 
-        if config.debug and file_path.split("/")[-1].startswith("all."):
+        if (config.debug or config.merge_media) and file_path.split("/")[-1].startswith("all."):
             # If debugging merge *.css to all.css and *.js to all.js
             site = self.server.sites.get(address)
             if site and site.settings["own"]:
@@ -607,7 +607,7 @@ class UiRequest(object):
                 # File not in allowed path
                 return self.error403()
             else:
-                if config.debug and match.group("inner_path").startswith("all."):
+                if (config.debug or config.merge_media) and match.group("inner_path").startswith("all."):
                     # If debugging merge *.css to all.css and *.js to all.js
                     from Debug import DebugMedia
                     DebugMedia.merge(file_path)


### PR DESCRIPTION
Currently, the only way to enable all.js/all.css merging is `--debug` option. However, `--debug`, uh, logs too much debug information and has other side effects. Thus, I'm adding a separate `--merge_media` option. Backward compatibility is retained.