### PR TITLE
Display a sponsor button in repository (py3)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://zeronet.io/docs/help_zeronet/donate/


### PR DESCRIPTION
I already created #2031 for this, but since default branch is now changed to `py3˙, the file also needs to be present in it.

(cherry picked from commit f08bea7f904fdac1a22fa39d57b359f68a776cfc)