### PR TITLE
Allow NOSANDBOX in local mode

### DIFF
--- a/plugins/disabled-Multiuser/MultiuserPlugin.py
+++ b/plugins/disabled-Multiuser/MultiuserPlugin.py
@@ -255,7 +255,8 @@ class UiWebsocketPlugin(object):
         self.cmd("injectScript", script)
 
     def actionPermissionAdd(self, to, permission):
-        if permission == "NOSANDBOX":
+        is_public_proxy_user = not config.multiuser_local and self.user.master_address not in local_master_addresses
+        if permission == "NOSANDBOX" and is_public_proxy_user:
             self.cmd("notification", ["info", "You can't disable sandbox on this proxy!"])
             self.response(to, {"error": "Denied by proxy"})
             return False


### PR DESCRIPTION
Even if Multiuser plugin is in local mode, it doesn't allow adding NOSANDBOX permission. This should be now fixed. See [this](http://127.0.0.1:43110/Talk.ZeroNetwork.bit/?Topic:1571571783_144CwRj8eynTUC9DtGHaNHR3wm9P2EhuAY) for details.