### PR TITLE
No restart after update

### DIFF
--- a/src/Ui/UiWebsocket.py
+++ b/src/Ui/UiWebsocket.py
@@ -1124,6 +1124,7 @@ class UiWebsocket(object):
 
             import main
             main.update_after_shutdown = True
+            main.restart_after_shutdown = True
             SiteManager.site_manager.save()
             main.file_server.stop()
             main.ui_server.stop()

--- a/zeronet.py
+++ b/zeronet.py
@@ -38,8 +38,9 @@ def main():
             import update
             print("Updating...")
             update.update()
-            print("Restarting...")
-            restart()
+            if main.restart_after_shutdown:
+                print("Restarting...")
+                restart()
         else:
             print("Shutting down...")
             prepareShutdown()


### PR DESCRIPTION
Check if it wants to restart after update before trying to restart ZeroNet.

It would leave the option to just "update and shutdown". It is also give a bit more flexibility for people using ZeroNet inside an application.