### PR TITLE
Don't share ignored files

### DIFF
--- a/src/Test/TestPeer.py
+++ b/src/Test/TestPeer.py
@@ -49,6 +49,10 @@ class TestPeer:
         buff = peer_file_server.getFile(site_temp.address, "content.json")
         assert b"sign" in buff.getvalue()
 
+        # Testing ignored file
+        buff = peer_file_server.getFile(site_temp.address, "js/ignored.json")
+        assert not buff
+
         connection.close()
         client.stop()
 


### PR DESCRIPTION
This allows sensitive data to be stored in ignored files. (caution: don't use it on proxies though)