### PR TITLE
Replace usage of deprecated API 'cgi.parse_qsl'

### DIFF
--- a/src/Ui/UiServer.py
+++ b/src/Ui/UiServer.py
@@ -1,6 +1,6 @@
 import logging
 import time
-import cgi
+import urllib
 import socket
 import gevent
 
@@ -118,7 +118,7 @@ class UiServer:
     def handleRequest(self, env, start_response):
         path = bytes(env["PATH_INFO"], "raw-unicode-escape").decode("utf8")
         if env.get("QUERY_STRING"):
-            get = dict(cgi.parse_qsl(env['QUERY_STRING']))
+            get = dict(urllib.parse.parse_qsl(env['QUERY_STRING']))
         else:
             get = {}
         ui_request = UiRequest(self, get, env, start_response)


### PR DESCRIPTION
Python 3.8.0 removed this deprecated API. We already use the replacement
`urllib.parse.parse_qsl` in `UIRequest.py`

Fixes #2306

Python Issue Reference: https://bugs.python.org/issue33843