### PR TITLE
Adding VTT MIME type and making sure that all MIME types starting with text/* are using UTF-8 character encoding.

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -35,6 +35,7 @@ content_types = {
     "json": "application/json",
     "sig": "application/pgp-signature",
     "txt": "text/plain",
+    "vtt": "text/vtt",
     "webmanifest": "application/manifest+json",
     "webp": "image/webp"
 }
@@ -292,7 +293,7 @@ class UiRequest(object):
             headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Cookie, Range"
             headers["Access-Control-Allow-Credentials"] = "true"
 
-        if content_type in ("text/plain", "text/html", "text/css", "application/javascript", "application/json", "application/manifest+json"):
+        if content_type.startswith("text") or content_type in ("application/javascript", "application/json", "application/manifest+json"):
             content_type += "; charset=utf-8"
 
         # Download instead of display file types that can be dangerous


### PR DESCRIPTION
VTT stands for "Video Text Tracks Format" and it requires UTF-8 character encoding. 
About VTT: https://www.w3.org/TR/webvtt1/

This will fix the "subtitles not shown at all" issue on videos which use them on ZeroNet.