### PR TITLE
Update Zeroname updater documentation

### DIFF
--- a/plugins/Zeroname/README.md
+++ b/plugins/Zeroname/README.md
@@ -22,6 +22,7 @@ rpcpassword=your-password
 rpcport=8336
 server=1
 txindex=1
+valueencoding=utf8
 ```
 
 Don't forget to change the `rpcuser` value and `rpcpassword` value!


### PR DESCRIPTION
Update documentation to add `valueencoding` configuration. It is required to avoid the value encoding error with old value registered.