### PR TITLE
Compression support & fixes

### DIFF
--- a/plugins/FilePack/FilePackPlugin.py
+++ b/plugins/FilePack/FilePackPlugin.py
@@ -21,9 +21,6 @@ def openArchive(archive_path, file_obj=None):
         if archive_path.endswith("tar.gz"):
             import tarfile
             archive_cache[archive_path] = tarfile.open(archive_path, fileobj=file_obj, mode="r:gz")
-        elif archive_path.endswith("tar.bz2"):
-            import tarfile
-            archive_cache[archive_path] = tarfile.open(archive_path, fileobj=file_obj, mode="r:bz2")
         else:
             import zipfile
             archive_cache[archive_path] = zipfile.ZipFile(file_obj or archive_path)
@@ -48,7 +45,7 @@ class UiRequestPlugin(object):
             file_obj = None
             path_parts = self.parsePath(path)
             file_path = "%s/%s/%s" % (config.data_dir, path_parts["address"], path_parts["inner_path"])
-            match = re.match("^(.*\.(?:tar.gz|tar.bz2|zip))/(.*)", file_path)
+            match = re.match("^(.*\.(?:tar.gz|zip))/(.*)", file_path)
             archive_path, path_within = match.groups()
             if archive_path not in archive_cache:
                 site = self.server.site_manager.get(path_parts["address"])
@@ -102,7 +99,7 @@ class UiRequestPlugin(object):
 class SiteStoragePlugin(object):
     def isFile(self, inner_path):
         if ".zip/" in inner_path or ".tar.gz/" in inner_path:
-            match = re.match("^(.*\.(?:tar.gz|tar.bz2|zip))/(.*)", inner_path)
+            match = re.match("^(.*\.(?:tar.gz|zip))/(.*)", inner_path)
             archive_inner_path, path_within = match.groups()
             return super(SiteStoragePlugin, self).isFile(archive_inner_path)
         else:
@@ -130,7 +127,7 @@ class SiteStoragePlugin(object):
 
     def walk(self, inner_path, *args, **kwags):
         if ".zip" in inner_path or ".tar.gz" in inner_path:
-            match = re.match("^(.*\.(?:tar.gz|tar.bz2|zip))(.*)", inner_path)
+            match = re.match("^(.*\.(?:tar.gz|zip))(.*)", inner_path)
             archive_inner_path, path_within = match.groups()
             archive = self.openArchive(archive_inner_path)
             path_within = path_within.lstrip("/")
@@ -154,7 +151,7 @@ class SiteStoragePlugin(object):
 
     def list(self, inner_path, *args, **kwags):
         if ".zip" in inner_path or ".tar.gz" in inner_path:
-            match = re.match("^(.*\.(?:tar.gz|tar.bz2|zip))(.*)", inner_path)
+            match = re.match("^(.*\.(?:tar.gz|zip))(.*)", inner_path)
             archive_inner_path, path_within = match.groups()
             archive = self.openArchive(archive_inner_path)
             path_within = path_within.lstrip("/")
@@ -181,7 +178,7 @@ class SiteStoragePlugin(object):
 
     def read(self, inner_path, mode="rb", **kwargs):
         if ".zip/" in inner_path or ".tar.gz/" in inner_path:
-            match = re.match("^(.*\.(?:tar.gz|tar.bz2|zip))(.*)", inner_path)
+            match = re.match("^(.*\.(?:tar.gz|zip))(.*)", inner_path)
             archive_inner_path, path_within = match.groups()
             archive = self.openArchive(archive_inner_path)
             path_within = path_within.lstrip("/")

--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -707,7 +707,7 @@ class UiRequest(object):
         return block
 
     # Stream a file to client
-    def actionFile(self, file_path, block_size=64 * 1024, send_header=True, header_length=True, header_noscript=False, header_allow_ajax=False, file_size=None, file_obj=None, path_parts=None):
+    def actionFile(self, file_path, block_size=64 * 1024, send_header=True, header_length=True, header_noscript=False, header_allow_ajax=False, extra_headers={}, file_size=None, file_obj=None, path_parts=None):
         file_name = os.path.basename(file_path)
 
         if file_size is None:
@@ -725,7 +725,10 @@ class UiRequest(object):
                 header_length = False
 
             if send_header:
-                extra_headers = {}
+                extra_headers = extra_headers.copy()
+                content_encoding = self.get.get("zeronet_content_encoding", "")
+                if all(part.strip() in ("gzip", "compress", "deflate", "identity", "br") for part in content_encoding.split(",")):
+                    extra_headers["Content-Encoding"] = content_encoding
                 extra_headers["Accept-Ranges"] = "bytes"
                 if header_length:
                     extra_headers["Content-Length"] = str(file_size)


### PR DESCRIPTION
1. Fix `.tar.bz2` archive support.
2. Send `Content-Encoding` header for `.gz` and `.br` files. This allows compressing files and using them directly, like `<script src="main.js.gz">`.