### PR TITLE
Added Custom Openssl Path for Native Clients and Fixed Tracker files provided are not loading on some systems

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -31,6 +31,7 @@ class Config(object):
 
         self.config_file = self.start_dir + "/zeronet.conf"
         self.data_dir = self.start_dir + "/data"
+        self.openssl_path = "default"
         self.log_dir = self.start_dir + "/log"
 
         self.trackers_file = False
@@ -108,6 +109,7 @@ class Config(object):
 
         config_file = self.start_dir + "/zeronet.conf"
         data_dir = self.start_dir + "/data"
+        openssl_path = "default"
         log_dir = self.start_dir + "/log"
 
         ip_local = ["127.0.0.1", "::1"]
@@ -259,6 +261,7 @@ class Config(object):
         self.parser.add_argument('--ip_external', help='Set reported external ip (tested on start if None)', metavar='ip', nargs='*')
         self.parser.add_argument('--offline', help='Disable network communication', action='store_true')
 
+        self.parser.add_argument('--openssl_path', help='Custom Path to OpenSSL Binary', default=openssl_path, metavar="path")
         self.parser.add_argument('--disable_udp', help='Disable UDP connections', action='store_true')
         self.parser.add_argument('--proxy', help='Socks proxy address', metavar='ip:port')
         self.parser.add_argument('--bind', help='Bind outgoing sockets to this address', metavar='ip')
@@ -321,6 +324,9 @@ class Config(object):
                     trackers_file_path = trackers_file
                 elif trackers_file.startswith("{data_dir}"):  # Relative to data_dir
                     trackers_file_path = trackers_file.replace("{data_dir}", self.data_dir)
+                elif trackers_file.startswith("data/"):
+                    # Relative to data_dir Useful for Unix Type Systems and Android Clients
+                    trackers_file_path = trackers_file.replace("data", self.data_dir)
                 else:  # Relative to zeronet.py
                     trackers_file_path = self.start_dir + "/" + trackers_file
 
@@ -479,7 +485,7 @@ class Config(object):
             for key, val in args.items():
                 if type(val) is list:
                     val = val[:]
-                if key in ("data_dir", "log_dir"):
+                if key in ("data_dir", "log_dir", "openssl_path"):
                     val = val.replace("\\", "/")
                 setattr(self, key, val)
 
@@ -563,6 +569,7 @@ class Config(object):
 
             "log_dir": os.path.abspath(self.log_dir),
             "data_dir": os.path.abspath(self.data_dir),
+            "openssl_path": os.path.abspath(self.openssl_path),
             "src_dir": os.path.dirname(os.path.abspath(__file__))
         }
 

--- a/src/Crypt/CryptConnection.py
+++ b/src/Crypt/CryptConnection.py
@@ -11,12 +11,15 @@ from util import helper
 
 class CryptConnectionManager:
     def __init__(self):
-        if sys.platform.startswith("win"):
-            self.openssl_bin = "tools\\openssl\\openssl.exe"
-        elif config.dist_type.startswith("bundle_linux"):
-            self.openssl_bin = "../runtime/bin/openssl"
+        if config.openssl_path != "default":
+            self.openssl_bin = config.openssl_path
         else:
-            self.openssl_bin = "openssl"
+            if sys.platform.startswith("win"):
+                self.openssl_bin = "tools\\openssl\\openssl.exe"
+            elif config.dist_type.startswith("bundle_linux"):
+                self.openssl_bin = "../runtime/bin/openssl"
+            else:
+                self.openssl_bin = "openssl"
 
         self.context_client = None
         self.context_server = None


### PR DESCRIPTION
This Parameter helpful where openssl path is not fixed always, we can also use this to reduce code verbosity by providing other like these and provide them as parameter
```
            if sys.platform.startswith("win"):
                self.openssl_bin = "tools\\openssl\\openssl.exe"
            elif config.dist_type.startswith("bundle_linux"):
                self.openssl_bin = "../runtime/bin/openssl"
            else:
                self.openssl_bin = "openssl"
```

Also Fixed Tracker files provided are not loading on some systems like Android client where path storage access is restricted