### PR TITLE
Fixes Tracker Files not accessed when there is custom data dir

### DIFF
--- a/src/Config.py
+++ b/src/Config.py
@@ -326,6 +326,9 @@ class Config(object):
                     trackers_file_path = trackers_file
                 elif trackers_file.startswith("{data_dir}"):  # Relative to data_dir
                     trackers_file_path = trackers_file.replace("{data_dir}", self.data_dir)
+                elif trackers_file.startswith("data/"):  # Relative to data_dir in string form.
+                    # This is Required if we use custom data dir
+                    trackers_file_path = trackers_file.replace("data", self.data_dir)
                 else:  # Relative to zeronet.py
                     trackers_file_path = self.start_dir + "/" + trackers_file
 


### PR DESCRIPTION
If we have string form of data dir like "data/trackers.json" and custom data conf applied to zeronet, there is no condition in loop to catch it. this will cause zeronet defaults to last default option, which in return is not valid path.