### PR TITLE
Fixed "LookupError: 'hex' is not a text encoding" on /StatsBootstrapper page

### DIFF
--- a/plugins/disabled-Bootstrapper/BootstrapperPlugin.py
+++ b/plugins/disabled-Bootstrapper/BootstrapperPlugin.py
@@ -150,7 +150,7 @@ class UiRequestPlugin(object):
             ).fetchall()
 
             yield "<br>%s (added: %s, peers: %s)<br>" % (
-                str(hash_row["hash"]).encode("hex"), hash_row["date_added"], len(peer_rows)
+                str(hash_row["hash"]).encode().hex(), hash_row["date_added"], len(peer_rows)
             )
             for peer_row in peer_rows:
                 yield " - {ip4: <30} {onion: <30} added: {date_added}, announced: {date_announced}<br>".format(**dict(peer_row))

--- a/plugins/disabled-Bootstrapper/BootstrapperPlugin.py
+++ b/plugins/disabled-Bootstrapper/BootstrapperPlugin.py
@@ -153,4 +153,4 @@ class UiRequestPlugin(object):
                 str(hash_row["hash"]).encode().hex(), hash_row["date_added"], len(peer_rows)
             )
             for peer_row in peer_rows:
-                yield " - {ip4: <30} {onion: <30} added: {date_added}, announced: {date_announced}<br>".format(**dict(peer_row))
+                yield " - {type} {address}:{port} added: {date_added}, announced: {date_announced}<br>".format(**dict(peer_row))


### PR DESCRIPTION
### Step 1: Please describe your environment

  * ZeroNet version: rev4458
  * Operating system: CentOS 8
  * Web browser: Chrome
  * Tor status: available
  * Opened port: yes
  * Special configuration: 

### Step 2: Describe the problem:

When enable plugin `Bootstrapper` and visit URl `http://127.0.0.1:43110/StatsBootstrapper` to show stats, page is blank and in log file i see error

```
[2020-02-26 21:59:31,593] ERROR    - UiWSGIHandler error: LookupError: 'hex' is not a text encoding; use codecs.encode() to handle arbitrary codecs in core/src/Ui/UiServer.py line 61 > ... > disabled-Bootstrapper/BootstrapperPlugin.py line 153
[2020-02-26 21:59:31,594] DEBUG    Ui.UiServer 127.0.0.1 - - [2020-02-26 21:59:31] "GET /StatsBootstrapper HTTP/1.1" 200 473 0.003000
```

#### Steps to reproduce:

  1. Enable `Bootstrapper` plugin
  2. Go to `http://127.0.0.1:43110/StatsBootstrapper`

#### Observed Results:

Errors in log file:
```
LookupError: 'hex' is not a text encoding; use codecs.encode() to handle arbitrary codecs in core/src/Ui/UiServer.py line 61 > ... > disabled-Bootstrapper/BootstrapperPlugin.py line 153
```

#### How to fix?

I created a patch.

Also fixed below error:
```
[22:55:58] - UiWSGIHandler error: KeyError: 'ip4' in UiServer.py line 61 > pywsgi.py line 924 > 908 > helper.py line 345 > disabled-Bootstrapper/BootstrapperPlugin.py line 157
[22:55:58] Ui.UiServer Error 500: UiWSGIHandler error: KeyError: ip4
```
