### PR TITLE
Fixed `Cache-Control` for .js and .css files - 10 minutes cache

### DIFF
--- a/src/Ui/UiRequest.py
+++ b/src/Ui/UiRequest.py
@@ -299,9 +299,6 @@ class UiRequest(object):
             headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Cookie, Range"
             headers["Access-Control-Allow-Credentials"] = "true"
 
-        if content_type in ("text/plain", "text/html", "text/css", "application/javascript", "application/json", "application/manifest+json"):
-            content_type += "; charset=utf-8"
-
         # Download instead of display file types that can be dangerous
         if re.findall("/svg|/xml|/x-shockwave-flash|/pdf", content_type):
             headers["Content-Disposition"] = "attachment"
@@ -311,6 +308,9 @@ class UiRequest(object):
             content_type.split("/", 1)[0] in ("image", "video", "font") or
             content_type in ("application/javascript", "text/css")
         )
+
+        if content_type in ("text/plain", "text/html", "text/css", "application/javascript", "application/json", "application/manifest+json"):
+            content_type += "; charset=utf-8"
 
         if status in (200, 206) and cacheable_type:  # Cache Css, Js, Image files for 10min
             headers["Cache-Control"] = "public, max-age=600"  # Cache 10 min


### PR DESCRIPTION
Hello,

When sending request `GET http://127.0.0.1:43110/uimedia/all.css?rev=4458` the response contains `Cache-Control: no-cache, no-store, private, must-revalidate, max-age=0`.
It means `.css` and `.js` files are not cached by the browser

I fixed that problem, now receive: `Cache-Control: public, max-age=600`

* * *

I change the order of code, check the `content-type` (`application/javascript` or `text/css`), at the end add charset `utf-8.