### PR TITLE
Disable process_result on websocket requests

### DIFF
--- a/src/lib/gevent_ws/__init__.py
+++ b/src/lib/gevent_ws/__init__.py
@@ -254,3 +254,8 @@ class WebSocketHandler(WSGIHandler):
         finally:
             self.time_finish = time.time()
             self.log_request()
+
+
+    def process_result(self):
+        if "wsgi.websocket" not in self.environ:
+            super(WebSocketHandler, self).process_result()


### PR DESCRIPTION
Removes a weird "UiWSGIHandler error: BrokenPipeError: Broken pipe" error. This didn't affect the connectivity or something, but some users on ZeroTalk told me about it so I fixed it.