### PR TITLE
Upgrade gevent-ws to v2.0.5

### DIFF
--- a/src/lib/gevent_ws/__init__.py
+++ b/src/lib/gevent_ws/__init__.py
@@ -211,7 +211,7 @@ class WebSocketHandler(WSGIHandler):
 
 
         http_connection = [s.strip().lower() for s in self.environ.get("HTTP_CONNECTION", "").split(",")]
-        if "upgrade" not in http_connection or self.environ.get("HTTP_UPGRADE", "") != "websocket":
+        if "upgrade" not in http_connection or self.environ.get("HTTP_UPGRADE", "").lower() != "websocket":
             # Not my problem
             return super(WebSocketHandler, self).handle_one_response()
 
@@ -259,3 +259,10 @@ class WebSocketHandler(WSGIHandler):
     def process_result(self):
         if "wsgi.websocket" not in self.environ:
             super(WebSocketHandler, self).process_result()
+
+    @property
+    def version(self):
+        if not self.environ:
+            return None
+
+        return self.environ.get('HTTP_SEC_WEBSOCKET_VERSION')


### PR DESCRIPTION
This makes `Upgrade` header case-insensitive. I'm not sure if this conforms to standards but some clients send `Websocket` instead of `websocket`.