### PR TITLE
Allow opening the sidebar while content.json is not loaded

### DIFF
--- a/plugins/Sidebar/SidebarPlugin.py
+++ b/plugins/Sidebar/SidebarPlugin.py
@@ -117,7 +117,7 @@ class UiWebsocketPlugin(object):
         peer_ips = [peer.key for peer in site.getConnectablePeers(20, allow_private=False)]
         peer_ips.sort(key=lambda peer_ip: ".onion:" in peer_ip)
         copy_link = "http://127.0.0.1:43110/%s/?zeronet_peers=%s" % (
-            site.content_manager.contents["content.json"].get("domain", site.address),
+            site.content_manager.contents.get("content.json", {}).get("domain", site.address),
             ",".join(peer_ips)
         )
 

--- a/plugins/Sidebar/media/Sidebar.css
+++ b/plugins/Sidebar/media/Sidebar.css
@@ -18,7 +18,7 @@
 .sidebar .link-right:active { background-color: #444 }
 /* SIDEBAR */
 
-.sidebar-container { width: 100%; height: 100%; overflow: hidden; position: fixed; }
+.sidebar-container { width: 100%; height: 100%; overflow: hidden; position: fixed; z-index: 2; }
 .sidebar { background-color: #212121; position: fixed; backface-visibility: hidden; right: -1200px; height: 100%; width: 1200px; } /*box-shadow: inset 0px 0px 10px #000*/
 .sidebar .content { margin: 30px; font-family: "Segoe UI Light", "Segoe UI", "Helvetica Neue"; color: white; width: 375px; height: 300px; font-weight: 200; transition: all 1s; opacity: 0 }
 .sidebar-container.loaded .content { opacity: 1; transform: none }

--- a/plugins/Sidebar/media/all.css
+++ b/plugins/Sidebar/media/all.css
@@ -130,7 +130,7 @@
 .sidebar .link-right:active { background-color: #444 }
 /* SIDEBAR */
 
-.sidebar-container { width: 100%; height: 100%; overflow: hidden; position: fixed; }
+.sidebar-container { width: 100%; height: 100%; overflow: hidden; position: fixed; z-index: 2; }
 .sidebar { background-color: #212121; position: fixed; -webkit-backface-visibility: hidden; -moz-backface-visibility: hidden; -o-backface-visibility: hidden; -ms-backface-visibility: hidden; backface-visibility: hidden ; right: -1200px; height: 100%; width: 1200px; } /*box-shadow: inset 0px 0px 10px #000*/
 .sidebar .content { margin: 30px; font-family: "Segoe UI Light", "Segoe UI", "Helvetica Neue"; color: white; width: 375px; height: 300px; font-weight: 200; -webkit-transition: all 1s; -moz-transition: all 1s; -o-transition: all 1s; -ms-transition: all 1s; transition: all 1s ; opacity: 0 }
 .sidebar-container.loaded .content { opacity: 1; -webkit-transform: none ; -moz-transform: none ; -o-transform: none ; -ms-transform: none ; transform: none  }


### PR DESCRIPTION
If one opens the sidebar of a site not being downloaded yet, the following error occurs:

```
  Internal error: KeyError('content.json',): 'content.json'
  UiWebsocket.py line 79 > 235 > Sidebar/SidebarPlugin.py line 527 > 120 > ContentDbDict.py line 59
```

Also, the sidebar is not visible.

This fixes the both issues.

For sites without peers, the only way to delete the site was to navigate to ZeroHellow, scroll the left panel to "Connecting sites", and delete the site from the list. Now those sites can be deleted from the sidebar.