### PR TITLE
Add support for compressed addresses

### DIFF
--- a/src/Crypt/CryptBitcoin.py
+++ b/src/Crypt/CryptBitcoin.py
@@ -58,9 +58,11 @@ def privatekeyToAddress(privatekey):  # Return address from private key
     try:
         if len(privatekey) == 64:
             privatekey_bin = bytes.fromhex(privatekey)
+            is_compressed = False
         else:
             privatekey_bin = sslcurve.wif_to_private(privatekey.encode())
-        return sslcurve.private_to_address(privatekey_bin, is_compressed=False).decode()
+            is_compressed = sslcurve.is_compressed(privatekey.encode())
+        return sslcurve.private_to_address(privatekey_bin, is_compressed=is_compressed).decode()
     except Exception:  # Invalid privatekey
         return False
 
@@ -68,10 +70,16 @@ def privatekeyToAddress(privatekey):  # Return address from private key
 def sign(data, privatekey):  # Return sign to data using private key
     if privatekey.startswith("23") and len(privatekey) > 52:
         return None  # Old style private key not supported
+    if len(privatekey) == 64:
+        privatekey_bin = bytes.fromhex(privatekey)
+        is_compressed = False
+    else:
+        privatekey_bin = sslcurve.wif_to_private(privatekey.encode())
+        is_compressed = sslcurve.is_compressed(privatekey.encode())
     return base64.b64encode(sslcurve.sign(
         data.encode(),
-        sslcurve.wif_to_private(privatekey.encode()),
-        is_compressed=False,
+        privatekey_bin,
+        is_compressed=is_compressed,
         recoverable=True,
         hash=dbl_format
     )).decode()

--- a/src/lib/sslcrypto/_ecc.py
+++ b/src/lib/sslcrypto/_ecc.py
@@ -296,6 +296,14 @@ class EllipticCurve:
             return x, y
 
 
+    def is_compressed(self, wif):
+        dec = base58.b58decode_check(wif)
+        if dec[0] != 0x80:
+            raise ValueError("Invalid network (expected mainnet)")
+        if len(dec) == 34 and dec[33] == 0x01:
+            return True
+        return False
+
     def new_private_key(self):
         return self._backend.new_private_key()
 
@@ -305,14 +313,16 @@ class EllipticCurve:
         return self._encode_public_key(x, y, is_compressed=is_compressed)
 
 
-    def private_to_wif(self, private_key):
-        return base58.b58encode_check(b"\x80" + private_key)
+    def private_to_wif(self, private_key, is_compressed=False):
+        return base58.b58encode_check(b"\x80" + private_key + (b"\x01" if is_compressed else b""))
 
 
     def wif_to_private(self, wif):
         dec = base58.b58decode_check(wif)
         if dec[0] != 0x80:
             raise ValueError("Invalid network (expected mainnet)")
+        if len(dec) == 34 and dec[33] == 0x01:
+            dec = dec[:-1]
         return dec[1:]
 
 


### PR DESCRIPTION
This adds support for compressed Bitcoin site addresses and closes #2501.

It's using `sslcrypto` changes from imachug/sslcrypto#7 to detect if WIF private key has compression flag and then uses it to correctly get address and sign content.

Apparently `verify` does not need to be modified. Sites with compressed addresses can be viewed on older versions, but signing them does not work (I'm not sure for signing of the user's content).