### PR TITLE
Fix redirect loop in Chrome 80

### DIFF
--- a/plugins/disabled-UiPassword/UiPasswordPlugin.py
+++ b/plugins/disabled-UiPassword/UiPasswordPlugin.py
@@ -65,7 +65,7 @@ class UiRequestPlugin(object):
                 url = self.env.get("HTTP_REFERER", "")
                 if not url or re.sub(r"\?.*", "", url).endswith("/Login"):
                     url = "/" + config.homepage
-                cookie_header = ('Set-Cookie', "session_id=%s;path=/;max-age=2592000;" % session_id)  # Max age = 30 days
+                cookie_header = ('Set-Cookie', "session_id=%s;path=/;max-age=2592000;secure;samesite=none;" % session_id)  # Max age = 30 days
                 self.start_response('301 Redirect', [('Location', url), cookie_header])
                 yield "Redirecting..."
 


### PR DESCRIPTION
This fixes the following error message from Chrome 80

A cookie associated with a cross-site resource at http://zeronet.example.com/ was set without the `SameSite` attribute. It has been blocked, as Chrome now only delivers cookies with cross-site requests if they are set with `SameSite=None` and `Secure`. You can review cookies in developer tools under Application>Storage>Cookies and see more details at https://www.chromestatus.com/feature/5088147346030592 and https://www.chromestatus.com/feature/5633521622188032.