### PR TITLE
Use Gevent prerelease for Python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 gevent>=1.1.0; python_version < "3.8"
-https://github.com/gevent/gevent/archive/master.zip; python_version >= "3.8"
+gevent>=1.5.0a2; python_version >= "3.8"
 msgpack>=0.4.4
 base58
 merkletools


### PR DESCRIPTION
This changes Gevent for Python 3.8 from using Git archive to the latest prerelease version. This enables wheel installation on supported systems and results in faster dependency installation.

However, a special case for Python 3.8 is still needed, because the changes were not released as 1.5 yet.