### PR TITLE
Remove Gevent dependency condition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-gevent>=1.1.0; python_version < "3.8"
-gevent>=1.5.0a2; python_version >= "3.8"
+gevent>=1.1.0
 msgpack>=0.4.4
 base58
 merkletools


### PR DESCRIPTION
As stable Gevent 1.5.0 with support for Python 3.8 was recently released, there is no need for special condition which installs custom Gevent version depending on Python version.