### PR TITLE
Add missing seekable() class method to BigFile plugin

### DIFF
--- a/plugins/Bigfile/BigfilePlugin.py
+++ b/plugins/Bigfile/BigfilePlugin.py
@@ -597,6 +597,9 @@ class BigFile(object):
                 whence = 0
             return self.f.seek(pos, whence)
 
+    def seekable(self):
+        return self.f.seekable()
+
     def tell(self):
         return self.f.tell()
 


### PR DESCRIPTION
Contributed by Ansho Rei who does not have a github account.

> A change in the python File class was introduced in 3.7 and BigFile should be adapted accordingly
> so small zip files still worked, but big ones resulted in a missing function error on seekable()
> ZeroNet is already bundled with python3.7

Called in the module here: https://github.com/python/cpython/blob/e05828055e5165cc7268ea3bea33adc502e054a1/Lib/zipfile.py#L837

Should be backwards compatible with older python3 versions.