### PR TITLE
Remove unnecessary debugger

### DIFF
--- a/src/Ui/media/all.js
+++ b/src/Ui/media/all.js
@@ -1877,7 +1877,6 @@ $.extend( $.easing,
               return false;
             });
           }
-          debugger;
           return _this.log("siteListModifiedFiles", num, res);
         };
       })(this));


### PR DESCRIPTION
It doesn't exist in the original `src/Ui/media/Wrapper.coffee` file.