### PR TITLE
Start testing on Python 3.9 and stop on EOL Py3.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 16
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
* https://devguide.python.org/devcycle/#end-of-life-branches
* https://devguide.python.org/#status-of-python-branches