### PR TITLE
Fix 404 error handler in UiFilePlugin

### DIFF
--- a/plugins/UiFileManager/UiFileManagerPlugin.py
+++ b/plugins/UiFileManager/UiFileManagerPlugin.py
@@ -73,6 +73,9 @@ class UiFileManagerPlugin(object):
             return super().error404(path)
 
         path_parts = self.parsePath(path)
+        if not path_parts:
+            return super().error404(path)
+
         site = self.server.site_manager.get(path_parts["request_address"])
 
         if not site or not site.content_manager.contents.get("content.json"):


### PR DESCRIPTION
Visiting http://127.0.0.1:43110/fdsgdfsgfds/ should show 404, not 500