### PR TITLE
feature: launch namecoin

### DIFF
--- a/plugins/disabled-ZeronameLocal/NamecoinUtils.py
+++ b/plugins/disabled-ZeronameLocal/NamecoinUtils.py
@@ -1,0 +1,43 @@
+import os, signal, json, requests, subprocess, time
+from pathlib import Path
+from configparser import ConfigParser
+import psutil
+
+
+def is_namecoin_installed():
+    home = str(Path.home())
+    dot_namecoin = os.path.join(home, '.namecoin')
+    is_dot_namecoin = os.path.exists(dot_namecoin)
+    return is_dot_namecoin
+
+
+def is_namecoin_running():
+    for proc in psutil.process_iter(['pid', 'name', 'username']):
+        if "namecoin" in proc.name():
+            return proc
+
+
+def get_namecoin_conf():
+    namecoin_conf = os.path.join(str(Path.home()), '.namecoin', 'namecoin.conf')
+    parser = ConfigParser()
+    with open(namecoin_conf) as stream:
+        parser.read_string("[fake-section]\n" + stream.read())
+        config = dict(parser.items('fake-section'))
+        return config
+
+
+def check_namecoin_rpc_conf(config):
+    if None in (config['rpcconnect'], config['rpcport'], config['rpcuser'], config['rpcpassword']):
+        return False
+    else:
+        return True
+
+
+def start_namecoin(path):
+    process = subprocess.Popen(["{}namecoind".format(path)])
+    return process.pid
+
+
+def kill_namecoin(pid):
+    os.kill(pid, signal.SIGTERM)
+    return True

--- a/plugins/disabled-ZeronameLocal/SiteManagerPlugin.py
+++ b/plugins/disabled-ZeronameLocal/SiteManagerPlugin.py
@@ -31,7 +31,7 @@ class SiteManagerPlugin(object):
         })
         self.log.debug("Namecoin config through CLI ? {}".format(self.config))
         self.log.debug("Namecoin installed ? {}".format(is_namecoin_installed()))
-        if is_namecoin_installed():
+        if sys.platform.startswith('linux') and is_namecoin_installed():
             self.log.debug("Namecoin running ? {}".format(is_namecoin_running()))
             if is_namecoin_running() is not None:
                 if check_namecoin_rpc_conf(self.config) is not True:


### PR DESCRIPTION
# Intent
Launch a Namecoin client such as Namecoin Core if it's installed when Zeronet launches.

## NamecoinUtils.py give a set of functions.
+ is_namecoin_installed check if a **.namecoin** folder exists in the (linux) user directory.
+ is_namecoin_running check if a running process contain the string namecoin.
+ check_namecoin_rpc_conf ensures that the necessary variables are set.
+ start_namecoin execute a subprocess of **namecoind**
+ kill_namecoin kill the given pid process

## Add __del__ function to SiteManagerPlugin.py
+ __del__ function kill the Namecoin client if it was launched by ZeroNet on ZeroNet shuts down.

## Process
+ self.config is initiated with CLI args, if provided
+  is namecoin installed ?
    + is namecoin running ?
        + if conf is not set, check for namecoin rpc conf in **namecoin.conf**
            + if there is no **namecoin.conf** raise missing parameters error.
    +  start **namecoind** (if path is given)

## Limitations
For the time being, it only works on linux, we can upgrade it for windows and macos users later

## Nota bene
I pushed with debug logs to make it easier for you to test, i will remove them before merging, if you agree