### PR TITLE
fix(sec): upgrade msgpack to 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 gevent==1.4.0; python_version <= "3.6"
 greenlet==0.4.16; python_version <= "3.6"
 gevent>=20.9.0; python_version >= "3.7"
-msgpack>=0.4.4
+msgpack>=0.6.0
 base58
 merkletools
 rsa


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in msgpack 0.4.4
- [MPS-2022-14994](https://www.oscs1024.com/hd/MPS-2022-14994)


### What did I do？
Upgrade msgpack from 0.4.4 to 0.6.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS